### PR TITLE
docs: add normative opxyloop-1.0 spec; author AGENTS.md and PROJECT_PLAN.md; add milestone handoff protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,154 @@
+# OP‑XY Vibe Coding – Agents & Components Spec
+
+Reference: `docs/opxyloop-1.0.md` is normative for the loop JSON.
+
+## Data Model Overview (MVP)
+- Single source of truth: `loop.json` on disk (git tracked).
+- Tracks: at least one drum track (GM‑safe fallback device map). Optional one pitched track in early UI.
+- CC lanes: base value per time; LFO: bipolar offset; merge = base + offset, clamped 0–127.
+- LFO phase: reset on Play and bar boundary by default; free‑run is future work.
+- Meta: tempo, length, docVersion, device profile. No seek/catch‑up in MVP.
+
+## Concurrency & Apply Rules
+- `docVersion`: monotonically increasing; stale patches are rejected and must rebase.
+- Atomic persistence: write to temp then rename; broadcast new doc on success.
+- Apply timing: structural edits (tempo/length/track defs) at next bar by default (allow explicit “apply now”); non‑structural (step toggle, velocity, CC point) on next tick.
+
+## Edge Rules & Invariants
+- No look‑ahead: schedule in true real time on current tick only.
+- Note‑off guarantee: every Note On emits a matching Note Off, even during live edits/hot‑swap. Maintain active‑notes registry; emit All Notes Off on stop/hot‑swap/disconnect.
+- Clock: external OP‑XY MIDI clock/transport authoritative by default; internal tempo override on explicit user request (then transmit MIDI Clock out).
+- Transport: bi‑directional play/stop/continue. SPP may reposition runtime, but no seek UI/API in MVP and no CC catch‑up on seek.
+- Safety: rate guards (~2.5k msgs/s global, ~800/track); shed lowest‑audibility CC bursts first.
+
+---
+
+## Vibe Coding Agent (LLM)
+
+| Area | Details |
+|---|---|
+| Purpose & Success | Co‑create music by authoring/editing `opxyloop-1.0` JSON; changes apply without breaking playback; docVersion stays in sync. |
+| Responsibilities | Generate patches or full JSON; respect schema; avoid structural churn unless asked; explain proposed changes when needed. |
+| Inputs | Current `doc{docVersion,json}` broadcasts; prompts from human. |
+| Outputs | `applyPatch{baseVersion,ops[]}` or `replaceJSON{baseVersion,doc}` via Conductor WS. |
+| Invariants | Single source of truth; no seek; structural edits usually next bar. |
+| APIs & Protocols | WebSocket envelopes `{type, ts, payload}`; RFC 6902 JSON Patch. |
+| Failures & Recovery | Patch rejected (stale): fetch latest, rebase, retry. Validation error: request fix‑it hints from Validator. |
+| Observability & KPIs | Patch acceptance rate, docVersion drift, edit latency to “effective at tick/bar”. |
+| Runbook | Connect to Conductor WS; subscribe to `doc` and `state`; send patches with correct `baseVersion`. |
+
+## Conductor (watcher + patch gate + broadcaster + metrics)
+
+| Area | Details |
+|---|---|
+| Purpose & Success | Canonical doc manager; gatekeeper for edits; broadcaster of state/doc/metrics; ensures atomicity and history. |
+| Responsibilities | Watch file; validate; apply patches/full replace; atomic write/rename; broadcast; commit batched history; clock/transport state; metrics. |
+| Inputs | FS events on `loop.json`; WS inbound: `play/stop/continue/setTempo/applyPatch/replaceJSON`. |
+| Outputs | WS outbound: `state`, `doc`, `metrics`, `error`; MIDI transport if internal clock. |
+| Invariants | Monotonic `docVersion`; no partial writes; next‑bar apply for structural edits. |
+| APIs & Protocols | WebSocket JSON; RFC 6902; Git CLI; file I/O with temp+rename. |
+| Failures & Recovery | File conflict: re‑read, reconcile, reject stale; crash during write: recover from last good file or last Git commit; device unplug: notify, panic. |
+| Observability & KPIs | jitter p95/p99, msgs/sec, dropped events, clockSource, SHA of canonical JSON, last commit age. |
+| Runbook | Start Conductor; open WS; choose clock source; optional “Checkpoint”; on anomalies, issue panic (All Notes Off). |
+
+## Playback Engine (real‑time MIDI)
+
+| Area | Details |
+|---|---|
+| Purpose & Success | Emit correct MIDI in real time with zero look‑ahead; preserve note lifecycles across edits. |
+| Responsibilities | Tick scheduling; active‑notes registry; Note On/Off; CC lane + LFO merge; All Notes Off on stop/hot‑swap/disconnect; implement rate guards. |
+| Inputs | Clock ticks (internal or external 24 PPQN); current doc snapshot; transport commands. |
+| Outputs | MIDI Note/CC/Clock; All Notes Off on panic/stop. |
+| Invariants | Note‑offs never orphaned; CC clamp 0–127; LFO phase reset on Play/bar by default. |
+| APIs & Protocols | CoreMIDI (macOS) or RtMidi; MIDI Clock (24 PPQN), Start/Stop/Continue; optional SPP reposition. |
+| Failures & Recovery | Missed Note Off detection: periodic reconciliation; device disconnect: panic and pause; overload: shed CCs first. |
+| Observability & KPIs | Tick jitter p95/p99, on/off ordering correctness, active‑notes count, shed counts. |
+| Runbook | Connect OP‑XY via USB‑C; select MIDI ports; verify clock source; test panic; verify drum map. |
+
+## Web UI (Safari grid)
+
+| Area | Details |
+|---|---|
+| Purpose & Success | DAW‑style grid editor that edits the same JSON losslessly; immediate feedback with transport controls. |
+| Responsibilities | Render doc; edit steps/velocities/CC points; send patches; show transport/clock; optional presence; no seek UI. |
+| Inputs | `doc`, `state`, `metrics`. |
+| Outputs | `applyPatch` / `replaceJSON`; optional `setTempo`; `play/stop/continue`. |
+| Invariants | Lossless round‑trip of JSON; structural edits default next bar. |
+| APIs & Protocols | WebSocket to Conductor; canonical JSON formatting; SHA‑256 footer hash optional for integrity. |
+| Failures & Recovery | Stale patch rejection: rebase UI buffer; WS drop: reconnect and resync; invalid edit: highlight and show Validator hints. |
+| Observability & KPIs | Patch round‑trip latency, rebases per minute, docVersion drift. |
+| Runbook | Open `ui/index.html` in Safari; connect WS; edit grid; use transport; trigger “Checkpoint” from UI as needed. |
+
+## Validator / Schema Agent
+
+| Area | Details |
+|---|---|
+| Purpose & Success | Enforce `opxyloop-1.0` schema; provide actionable fix‑it hints. |
+| Responsibilities | Validate on load/patch; normalize/canonicalize; surface errors with pointers; maintain canonical formatting. |
+| Inputs | Candidate JSON or patch results; normative spec. |
+| Outputs | Pass/Fail with error path/messages; possibly auto‑fix suggestions. |
+| Invariants | Spec‑compliant JSON only; stable formatting for diffs. |
+| APIs & Protocols | JSON Schema (draft 2020‑12) or custom validator; formatter. |
+| Failures & Recovery | On fail: reject write, emit `error{code,details}`; do not partially apply. |
+| Observability & KPIs | Validation latency; error rate by category. |
+| Runbook | Load spec, validate on every change, refuse non‑conformant writes. |
+
+## Git Historian
+
+| Area | Details |
+|---|---|
+| Purpose & Success | Durable history with batched commits and manual checkpoints. |
+| Responsibilities | Batch commits every 3–5s or on “Checkpoint”; include `docVersion` in messages; manage migrations/versioning. |
+| Inputs | File changes; operator “Checkpoint”. |
+| Outputs | Git commits; tags for checkpoints; migration scripts if schema bumps. |
+| Invariants | Canonical JSON formatting for stable diffs. |
+| APIs & Protocols | Git CLI. |
+| Failures & Recovery | Commit failure: retry/backoff; crash: recover from last commit. |
+| Observability & KPIs | Time since last commit, commit size, rollback success. |
+| Runbook | Ensure repo initialized; configure author; verify `.gitignore`; review diffs; checkpoint before risky edits. |
+
+## Test Harness Agent
+
+| Area | Details |
+|---|---|
+| Purpose & Success | Deterministically verify timing/order/invariants with virtual MIDI and synthetic clocks. |
+| Responsibilities | Provide virtual MIDI destination; drive internal/external clock; capture events with timestamps; DSL assertions; metrics capture. |
+| Inputs | Test scenarios; expected DSL; current code. |
+| Outputs | Pass/fail with timing windows (tolerances, not absolutes); metrics. |
+| Invariants | Note‑off never orphaned; no events after stop; CC/LFO rates within caps. |
+| APIs & Protocols | Python test runner; virtual MIDI backend; DSL parser. |
+| Failures & Recovery | Flaky timing: widen tolerances within budget; parallelize with isolation. |
+| Observability & KPIs | Jitter distributions, dropped counts, event throughput. |
+| Runbook | Run tests with virtual MIDI; simulate external clock; assert expectations. |
+
+## WebSocket Types (first cut)
+- Inbound: `play`, `stop`, `continue`, `setTempo{bpm}`, `applyPatch{baseVersion,ops[]}`, `replaceJSON{baseVersion,doc}`.
+- Outbound: `state{transport,clockSource,bpm,barBeatTick}`, `doc{docVersion,json}`, `error{code,message,details}`, `metrics{msgPerSec,jitterMsP95,dropped,clockSrc}`.
+
+## Schema Integration Tasks & Canonicalization
+- Author/align JSON Schema and examples per spec; define drum device profile map with GM fallback.
+- Define canonical formatting (ordering, whitespace) and hashing policy.
+- Implement validator and canonicalizer; add fixtures under `conductor/tests/fixtures/*.json`.
+- Document velocity semantics: Accent ≥105, normal 70–100, ghost 30–55. Guardrail: max ratchet density = 8/step.
+
+## Milestone Handoff & Progress Pointers
+- Update this file while working through milestones in `PROJECT_PLAN.md` to leave precise pickup instructions for the next agent.
+- Add an entry at the top of the Progress Log with:
+  - Milestone ID and title (e.g., `M2 – Engine Skeleton + Note Lifecycle`).
+  - Completed: succinct bullet(s) of finished work.
+  - Pickup: the next concrete step with file/function paths.
+  - Verify: exact command(s)/tests to run; expected outcome.
+  - Context: related commits/checkpoints, `docVersion`, open questions.
+- Keep latest entry first; timestamp each entry in ISO format.
+
+### Example Entry
+```
+[2025-09-13T16:40:00Z] M2 – Engine Skeleton + Note Lifecycle
+- Completed: active-notes ledger; demo-note passes with paired on/off ≤5ms tolerance.
+- Pickup: implement bar-boundary reconciliation in `conductor/midi_engine.py::reconcile_overdue_offs` and wire panic to transport stop.
+- Verify: `make test TESTS=conductor/tests/test_rt_sanity.py::test_orphan_off_guard` and `make demo-note`.
+- Context: checkpoint tag `ckpt-m2a`, `docVersion=43`.
+```
+
+## Progress Log
+- (Add newest entries above this line.)

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,183 @@
+# OP‑XY Vibe Coding – Project Plan
+
+## A. Overview
+- Problem: Let a human co‑create music with a “vibe coding” agent that edits a canonical loop JSON (`opxyloop‑1.0`) which a Python engine plays in real time to the OP‑XY device.
+- Objectives: glitch‑free real‑time playback, bulletproof note‑off lifecycle during edits/hot‑swap, faithful adherence to `docs/opxyloop-1.0.md`, observable behavior with tight jitter bounds, and zero‑data‑loss persistence via Git.
+- Scope (MVP): Conductor (file watcher + WS), real‑time playback engine, Web UI grid, JSON Patch edits, external clock priority with internal override, Git history, tests and metrics. Single drum track required; one pitched track optional in v0 UI.
+- Non‑goals (MVP): seek/catch‑up behavior, sustain/pedal, free‑running LFOs, multi‑track drums beyond one track.
+
+## Early Proof Points (fast confidence)
+- P0: Spec + fixtures load
+  - Load `docs/opxyloop-1.0.md`; add 3 minimal fixtures in `conductor/tests/fixtures/` (empty loop, drum bar with accent, CC+LFO example). Validator accepts them.
+- P1: Clock smoke tests
+  - Internal clock: 24 PPQN metronome logs tick deltas; p95 jitter < 2.0 ms on dev machine.
+  - External clock simulator: feed synthetic pulses; state reflects pulses accurately.
+- P2: Note lifecycle micro‑demo
+  - Engine stub emits a single Note On then off at exact gate without device (virtual sink). Log shows paired on/off with delta within tolerance. Panic triggers send All Notes Off across channels.
+- P3: Patch gating
+  - Conductor rejects stale patch; accepts valid patch; atomic write proves no torn file; `docVersion` increments.
+
+## B. Architecture Diagram (ASCII)
+```
+Human ⇄ LLM (Codex)
+          │            
+          ▼            
+      Conductor ⇄ Playback Engine ⇄ OP‑XY (USB‑C MIDI)
+          ▲            
+Human ⇄ Web UI ┘        
+
+Conductor ⇄ Git (batched commits)
+Conductor ⇄ loop.json (atomic write/watch)
+Spec: docs/opxyloop-1.0.md (normative)
+```
+
+## C. Requirements
+- Functional:
+  - Real‑time scheduling with no look‑ahead; events fire on current tick.
+  - External MIDI clock/transport (OP‑XY) is authoritative by default.
+  - Internal tempo override on request; transmit MIDI Clock so OP‑XY follows.
+  - Bi‑directional transport: play/stop/continue; optional SPP reposition (no seek UI/API).
+  - JSON ownership: `loop.json` on disk is canonical; JSON Patch (RFC 6902) or full replace.
+  - Single drum track (GM‑safe fallback); velocity semantics: Accent ≥105, normal 70–100, ghost 30–55; max ratchet density 8/step.
+  - CC & LFO: base + bipolar offset, clamp 0–127; phase reset on Play and bar boundary; no catch‑up on seek.
+  - Note‑off guarantee across edits/hot‑swap; All Notes Off on stop/hot‑swap/disconnect.
+  - Change timing: structural at next bar by default with “apply now” override; non‑structural next tick.
+  - No seek/catch‑up in MVP.
+- Non‑functional:
+  - Latency/jitter targets: track p95/p99 tick jitter; message ordering correctness; throughput within ~2.5k msgs/s global, ~800/track.
+  - Safety/panic: rigorous active‑notes accounting; All Notes Off on panic.
+  - Atomicity/durability: temp+rename writes; Git batched commits (3–5s) and manual “Checkpoint”.
+  - Testability: virtual MIDI, synthetic clock (internal/external), expectation DSL.
+  - Observability: broadcast metrics (msgPerSec, jitterMsP95/p99, dropped, clockSrc); hash of canonical JSON.
+
+## D. Playback Engine Strategy (no look‑ahead)
+- Algorithm (tick loop):
+  - Receive clock ticks (24 PPQN) from internal timer or external MIDI Clock.
+  - On each tick T: compute due events for T only (no future scheduling). Emit Note On/Off and CC for T, then return to wait.
+  - Pairing: when emitting Note On, compute off_tick = on_tick + length_in_ticks; create note_id and push into active‑notes ledger keyed by (channel,pitch) as a stack to support overlapping notes; schedule off on that exact tick even if the JSON changes.
+  - Reconciliation: on each bar boundary and on transport stop, reconcile ledger (send Note Off for any overdue); always emit All Notes Off on stop/hot‑swap/disconnect.
+- Data structures:
+  - Active‑notes ledger: dict[(ch,pitch)] -> stack of {note_id, off_tick}.
+  - Pending structural doc: staged doc applied at next bar; non‑structural deltas applied at next tick.
+  - Rate guard counters: global and per‑track rolling window; lowest‑audibility CCs shed first.
+- Threading & timing:
+  - Single timing thread for tick loop; all WS/file events post messages to it via lock‑free queue. Use monotonic time; avoid allocations in tick path (pre‑allocate buffers).
+  - External clock: derive tick times from incoming pulses; if pulses stall beyond timeout, auto‑pause and surface error.
+- Transport & SPP:
+  - Start/Stop/Continue honored both ways. If SPP arrives with Start/Continue, reposition runtime to that location; no UI/API seek and no CC catch‑up.
+- CC & LFO:
+  - At tick, CC_value = clamp(base_value + lfo_offset_bipolar, 0..127). LFO phase resets on Play and bar boundary.
+- Safety:
+  - Panic command: iterate channels and emit All Notes Off; clear ledger. On device reconnect, send baseline CCs if needed.
+
+## E. Interfaces & Contracts
+
+## D. Interfaces & Contracts
+- WebSocket Envelopes: `{type, ts, payload}`.
+  - Inbound: `play`, `stop`, `continue`, `setTempo{bpm}`, `applyPatch{baseVersion,ops[]}`, `replaceJSON{baseVersion,doc}`.
+  - Outbound: `state{transport,clockSource,bpm,barBeatTick}`, `doc{docVersion,json}`, `metrics{msgPerSec,jitterMsP95,jitterMsP99,dropped,clockSrc}`, `error{code,message,details}`.
+- Examples:
+  - `{"type":"applyPatch","ts":1699999999,"payload":{"baseVersion":42,"ops":[{"op":"replace","path":"/tracks/0/steps/3/vel","value":110}]}}`
+  - `{"type":"state","payload":{"transport":"playing","clockSource":"external","bpm":120,"barBeatTick":"2:1:0"}}`
+- Directory Layout:
+```
+project/
+  conductor/
+    app.py
+    ws_api.py
+    midi_engine.py
+    clock.py
+    store.py
+    tests/
+      fixtures/*.json
+      test_rt_sanity.py
+  ui/
+    index.html
+    app.js
+  docs/
+    opxyloop-1.0.md
+  loop.json
+  README.md
+```
+- Canonical JSON formatting & hashing:
+  - Deterministic key ordering and whitespace; newline at EOF.
+  - UI may display an SHA‑256 of canonical JSON (footer/comment out of band) for user confidence; Conductor keeps authoritative hash internally.
+- Validation pipeline:
+  - On every patch/replace: validate against `docs/opxyloop-1.0.md` schema; normalize to canonical form; reject with `error{code,details}` if invalid.
+  - Canonical JSON hash: compute (SHA‑256) for metrics; optional UI display.
+
+## F. Milestones & Acceptance Criteria
+- M0: Spec, Fixtures, Canonicalizer
+  - Deliverables: load `docs/opxyloop-1.0.md`; implement validator + canonical formatter; fixtures (empty, drum, CC+LFO).
+  - DoD tests: fixtures validate; canonical formatting stable hash; invalid examples rejected with pinpointed errors.
+- M1: Clock Foundations
+  - Deliverables: internal clock (24 PPQN) and synthetic external clock driver; timing logger with jitter stats; panic command skeleton.
+  - DoD tests: p95 tick jitter < 2.0 ms (dev) and < 4.0 ms (CI); start/stop/continue reflected in state.
+- M2: Engine Skeleton + Note Lifecycle
+  - Deliverables: active‑notes ledger; on->off pairing; All Notes Off; no device I/O (virtual sink).
+  - DoD tests: micro‑demo proves paired on/off within tolerance; “orphan guard” reconciliation clears overdue offs; post‑stop silence for ≥200 ms.
+- M3: Real‑time Playback (Internal Clock)
+  - Deliverables: map doc steps to ticks; drums path; velocity semantics; rate caps enforced; no look‑ahead.
+  - DoD tests: DSL asserts NoteOn/Off ordering and timing windows on fixtures; ledger never leaks; CC clamp verified.
+- M4: External Clock Follow
+  - Deliverables: MIDI start/stop/continue/clock handling; optional SPP reposition.
+  - DoD tests: synthetic external pulses drive playback; tempo changes tracked; stop/continue correct; SPP reposition honored without catch‑up.
+- M5: Edits & Persistence
+  - Deliverables: JSON Patch apply & reject stale; atomic temp+rename; next‑bar apply for structural edits; UI can patch simple toggles.
+  - DoD tests: edits during sounding notes preserve note‑offs; structural edits delayed to bar; docVersion monotonic; atomicity proven.
+- M6: LFO/CC Implementation
+  - Deliverables: CC lane + bipolar LFO offset; clamp; phase reset on Play/bar; rate guard shedding of CC bursts.
+  - DoD tests: DSL verifies `atLeastHz` behavior and clamping; shedding triggers under load without affecting notes.
+- M7: Git History & Checkpoints
+  - Deliverables: batched commits (3–5s) including docVersion; manual “Checkpoint”; crash recovery.
+  - DoD tests: simulate crash between writes and recover from last commit; clear commit messages.
+- M8: Web UI v0
+  - Deliverables: Safari grid for single drum + one pitched track; lossless JSON round‑trip; transport controls.
+  - DoD tests: UI patches apply; stale rebased; doc reflects instantly; no seek UI.
+- M9: Observability & SLOs
+  - Deliverables: metrics broadcast (msgPerSec, jitter p95/p99, dropped, clockSrc, activeNotes, hash); structured event logs.
+  - DoD tests: harness consumes metrics and asserts thresholds; logs include note_id with schedule vs emit delta.
+
+## G. Test Harness Spec
+- Virtual MIDI destination to capture all MIDI; timestamp events.
+- Synthetic clock drivers: internal and simulated external (24 PPQN + Start/Stop/Continue + optional SPP).
+- DSL examples:
+```
+@bpm 120
+expect on  ch10 36 vel>=105 within 10ms of 0.000s
+expect off ch10 36 within 5ms  of 0.250s
+expect cc  ch1  74 atLeastHz 120 for 2.0s
+# Edit while a note is sounding — note-off must still occur:
+during edit replaceJSON {...}
+expect off ch1 60 within 5ms of 0.500s  # note-off not lost
+after stop expect no on|cc for 200ms; allNotesOff observed
+```
+- Timing tolerances: use windows (p95/p99) not absolutes; define flakiness budget; CI parallelism with isolated virtual MIDI ports per worker.
+ - Determinism aids: use monotonic fake time in unit tests; reserve real‑time tolerance tests for integration layer.
+ - Coverage focus: note‑off during live edits, structural apply next bar, CC+LFO merge clamp, panic after stop/hot‑swap/disconnect.
+
+## H. Risks & Mitigations
+- Real‑time jitter: use high‑priority timing loop; CoreMIDI timestamps where possible; minimize GC/allocs; precompute step state per tick.
+- File watcher edge cases: debounce, re‑read after writes, guard partial writes with temp+rename.
+- External clock instability: smooth BPM estimation; handle missing clocks with timeout and auto‑pause.
+- OP‑XY disconnects: detect promptly; emit panic; auto‑retry connection; surface error state.
+- Note‑off integrity: maintain active‑notes registry across doc swaps; periodic reconciliation; All Notes Off on stop/hot‑swap/disconnect.
+ - Bug traps: assert no events 200 ms after stop; watchdog for overdue offs; drop CCs first under load.
+
+## I. Backlog / Future
+- Multi‑track drums; choke groups; per‑LFO free‑run; humanize/swing layer; device profile tooling; advanced UI (automation curves); seek and catch‑up.
+
+## J. Open Questions
+- SPP handling in MVP: honor reposition when provided, or defer? (Current: may reposition runtime; no seek UI.)
+- Canonical JSON hash exposure: UI footer or WS‑only?
+- Minimum macOS version and CoreMIDI backend constraints?
+- Exact metrics schema versioning and retention policy?
+
+## Notes on Spec Reference
+- `docs/opxyloop-1.0.md` is the normative reference and is present in this repo. Track tasks: schema enforcement in validator, canonical formatting rules, device maps, fixtures, and validator wiring to Conductor writes.
+
+## Runbook (manual checks through M3)
+- Start Conductor in dev mode; watch logs.
+- P1: run clock smoke (`make clock-smoke`): verify p95 jitter < 2 ms (dev).
+- P2: run `make demo-note`: observe one Note On at t=0.000 and Note Off at t=gate with delta ≤ 5 ms.
+- P3: apply a patch during the sounding note: verify off still occurs at scheduled time; then `stop` and confirm 200 ms silence and All Notes Off observed.

--- a/docs/opxyloop-1.0.md
+++ b/docs/opxyloop-1.0.md
@@ -1,0 +1,513 @@
+# OP‑XY Loop JSON Specification (opxyloop‑1.0)
+
+## Preamble
+
+**What this is.** A compact, JSON‑based loop format for **vibe‑coding** musical ideas with large language models (LLMs), quick human edits, and reliable MIDI playback on the OP‑XY. One file = one loop. You can regenerate, tweak, and audition rapidly without wrestling DAW projects or opaque binary formats.
+
+**What you can do with it.**  
+- **Generate with an LLM:** Keys are stable, field names are explicit, and defaults are predictable—so models can create and modify patterns safely.  
+- **Edit by hand or UI:** The structure maps cleanly to a step grid, plus lanes for CC and LFO modulation.  
+- **Play it back:** A lightweight runtime reads the JSON and schedules notes/automation to the OP‑XY over MIDI.
+
+**End goals.**  
+- **Fast idea‑to‑sound loop** for composition and prototyping.  
+- **Deterministic playback** with minimal hidden state—easy to diff, version, and share.  
+- **Musical context aware:** Optional key/mode for degree‑based notes and Roman‑numeral chords.  
+- **Device‑friendly:** Keep OP‑XY specifics (fixed CC mapping, engines) out of the data where possible.
+
+**Scope.** This specification covers a **single looping pattern** per document. Scenes/arrangements and file‑level time‑signature changes are intentionally out of scope. The OP‑XY owns its internal meter; this format doesn’t try to change it.
+
+---
+
+## 1. Top‑level object
+
+A valid **opxyloop‑1.0** document is a JSON object with these keys:
+
+| Key | Required | Description |
+| :---- | :---- | :---- |
+| **version** | Yes | Must equal `"opxyloop-1.0"` (schema identifier). |
+| **meta** | Yes | Global timing and optional tonal context (see §2). |
+| **deviceProfile** | No | Device defaults for MIDI port and drum note mappings (see §3). |
+| **tracks** | Yes | Array of track objects (see §4). |
+
+---
+
+## 2. `meta` object
+
+Defines the global timebase for the loop and, optionally, its tonal context for degree/chord resolution.
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **tempo** | number | Yes | Beats per minute used by the playback engine to drive MIDI clock. |
+| **ppq** | integer | Yes | Pulses per quarter note (e.g., 96, 480) for internal tick math. |
+| **stepsPerBar** | integer | Yes | Step grid per bar (e.g., 16 for a 1/16th grid). |
+| **swing** | number 0–1 | No | Swing amount applied to every second grid subdivision. |
+| **key** | string | No | Root key for resolving degrees/chord numerals (e.g., `"C"`, `"F#"`). |
+| **mode** | string | No | Scale mode: `"major"`, `"minor"`, or modal names (`"ionian"`, `"dorian"`, etc.). |
+
+> If `key`/`mode` are omitted, use absolute pitches or absolute chord symbols instead of relative numerals.
+
+---
+
+## 3. `deviceProfile` object
+
+Provides per‑project settings specific to the connected OP‑XY device.
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **portName** | string | No | MIDI port name to send messages to (e.g., `"OP-XY"`). |
+| **drumMap** | object | No | Friendly drum names mapped to MIDI note numbers (e.g., `"kick": 36`). |
+
+### 3.1 `drumMap` example
+
+```json
+{
+  "portName": "OP-XY",
+  "drumMap": { "kick": 36, "snare": 38, "ch": 42, "oh": 46, "clap": 39 }
+}
+```
+
+---
+
+## 4. `tracks` array
+
+Each track loops independently over its pattern length and targets a single MIDI channel/engine.
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **id** | string | Yes | Unique identifier (e.g., `"t-drum"`). |
+| **name** | string | Yes | Human‑readable name (e.g., `"Drums"`). |
+| **type** | string | Yes | OP‑XY synth engine (e.g., `"sampler"`, `"multiSampler"`, `"axis"`, `"dissolve"`). |
+| **midiChannel** | integer 0–15 | Yes | MIDI channel for this track. |
+| **role** | string | No | High‑level musical role label (annotation only; no playback effect). Recommended values: `"drums"`, `"bass"`, `"pad"`, `"pluck"`, `"lead"`, `"keys"`, `"piano"`, `"guitar"`, `"fx"`, `"vox"`. |
+| **pattern** | object | Yes | Loop definition (see §5). |
+| **ccLanes** | array | No | Continuous‑controller automation (see §6). |
+| **lfos** | array | No | Runtime LFO modulators (see §7). |
+
+> *Note:* There is no `programChange` or `muted` field in this schema; omit a track to silence it.
+
+### 4.1 Track role label (optional)
+
+- `role` is **pure metadata** for editors/generators (e.g., grouping, color, suggested register/density).  
+- Players/readers **must not** change MIDI/audio behavior based on `role`.  
+- The `"drums"` role **covers both drum kit and auxiliary percussion**.  
+- The underlying structure remains `tracks → pattern → steps → events`.
+
+---
+
+## 5. `pattern` object
+
+Defines the looping note content for a track.
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **lengthBars** | integer ≥ 1 | Yes | Number of bars in the loop before it restarts. |
+| **steps** | array of **Step** | Yes | Sparse array of steps; omit silent indices. |
+
+### 5.1 Step object
+
+Describes notes (or rests) beginning at a grid position.
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **idx** | integer ≥ 0 | Yes | Absolute step index: `bar * stepsPerBar + step` (zero‑based). |
+| **events** | array of **NoteEvent** | No | One or more note events at this step; empty/omitted = rest. |
+| **tuplet** | "triplet" \| "quintuplet" \| "septuplet" | No | Non‑standard subdivision across the step. |
+| **mute** | boolean | No | If `true`, ignore all events at this step. |
+
+### 5.1.1 NoteEvent object
+
+A NoteEvent can represent a **single pitch/degree** *or* an **entire chord**. All common timing/dynamics fields apply in either case.
+
+| Field | Type / range | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **pitch** | integer 0–127 | Yes\* | Absolute MIDI note number. Use for fixed‑pitch tracks (drums or specific notes). |
+| **degree** | integer 1–7 | Yes\* | Scale degree relative to the track’s key/scale; typically used with `octaveOffset`. |
+| **octaveOffset** | integer | No | Octave shift applied with `degree` to place the note in register. |
+| **chord** | string | Yes\* | Shorthand for a chord (relative or absolute), e.g., `Imaj7`, `V7`, `vi7`, `IVadd9`, `Cmaj7`, `Am7`, `G7(b9)`, `Vsus2`, `Imaj7/3`. When provided, this single NoteEvent requests the full chord. |
+| **lengthSteps** | integer ≥ 1 | Yes | Number of grid steps to hold the note/chord. |
+| **velocity** | integer 1–127 | Yes | Velocity for the note or for all chord tones (unless `velocities` provided). |
+| **prob** | number 0–1 | No | Probability of playing (applies to the whole event or chord). |
+| **gate** | number 0–1 | No | Percentage of nominal duration to hold (staccato/legato). |
+| **microshiftMs** | integer | No | Shift in milliseconds relative to the step boundary (humanize). |
+| **ratchet** | integer ≥ 2 | No | Evenly spaced retriggers within the step; probability applies to the group. |
+| **meta** | object | No | Freeform metadata for UI/articulation hints. |
+
+\* A NoteEvent must include **one of**: `pitch`, `degree`, or `chord`. When `degree` is used, include `octaveOffset`. When `chord` is used, timing/dynamics fields apply to the chord as a whole.
+
+#### Optional chord rendering hints
+
+These hints control how a chord is voiced/realized when `chord` is present.
+
+| Field | Type | Description |
+| :---- | :---- | :---- |
+| **invert** | integer ≥ 0 | Inversion index (`0`=root position, `1`=first inversion, …). |
+| **register** | `[string, string]` | Clamp realized pitches to a range (e.g., `["C3","B4"]`). |
+| **voicing** | string | Voicing hint, e.g., `"close"`, `"open-4"`, `"spread-5"`. |
+| **omit** | array of strings | Omit chord degrees by symbol: `"3"`, `"5"`, `"7"`, etc. |
+| **velocities** | array of ints | Per‑tone velocities (low→high). |
+| **rollMs** | integer | Arpeggiated “strum” delay between adjacent tones (ms). |
+
+#### Chord symbol grammar
+
+- **Relative (uses `meta.key`/`mode`):** `I`, `ii`, `iii`, `IV`, `V`, `vi`, `vii°` with optional quality: `maj`, `min`, `dim`, `aug`, `7`, `maj7`, `min7`, `ø7`, `sus2`, `sus4`, `add9`, `9`, `11`, `13`. Examples: `Imaj7`, `Vsus2`, `ii7`, `V7(b9)`, `IVadd9`.  
+- **Absolute:** `Cmaj7`, `Am7`, `Fadd9`, `G7(b9)`.  
+- **Slash bass:** `Imaj7/3`, `G7/B`.  
+- **Defaults:** Unspecified qualities resolve diatonically for the given mode.
+
+**Implementation notes for `chord` expansion**  
+- Expand a chord NoteEvent into multiple per‑pitch events internally, sharing timing and probability unless overridden.  
+- Tools lacking chord support may pre‑expand chords into ordinary NoteEvents.  
+- If no inversion/voicing hints are provided, use close position within a practical register (default `["C3","B4"]`).
+
+### 5.1.2 DrumKit — single‑track drum authoring helper
+
+
+
+Author all drum parts in **one track** using compact pattern strings. The **playback engine reads `drumKit` directly** and schedules hits at runtime—**no pre‑conversion to `steps → events` is required**. Placed here because it maps cleanly to the **Step/NoteEvent timing model**. Tools that don’t implement `drumKit` can ignore it, or optionally convert it into `steps` themselves if needed for editing workflows.
+
+**Location:** Optional field on a *drum track object* (typically `type: "sampler"`).  
+**Effect:** Schedules hits at specific `Step.idx` values based on per‑bar pattern strings.
+
+#### Fields
+
+Within a drum track, add a `drumKit` object with these fields:
+
+- **patterns** (array of **DrumPatternSpec**) — **required**.
+- **repeatBars** (integer ≥ 1) — optional. Repeat all listed patterns forward from each `bar` for this many bars; clamped to the track’s `pattern.lengthBars`. Default: `1`.
+- **lengthSteps** (integer ≥ 1) — optional. Default note length for emitted hits. Default: `1`.
+
+**DrumPatternSpec** (elements of `drumKit.patterns`):
+
+- **bar** (integer ≥ 1) — the starting bar where this pattern applies.
+- **key** (string) — **must** be a key in `deviceProfile.drumMap` (e.g., `"kick"`, `"snare"`, `"clap"`, `"ch"`, `"oh"`).
+- **pattern** (string) — exactly **`meta.stepsPerBar`** characters; allowed chars: `x` (hit), `.` or `-` (rest). No whitespace.
+- **vel** (integer 1–127, optional) — velocity for all hits produced by this spec; if omitted, use a reasonable default (e.g., 100).
+- **lengthSteps** (integer ≥ 1, optional) — per‑spec override; falls back to `drumKit.lengthSteps` if not set.
+
+> **First‑class helper.** `drumKit` is valid at playback time. Implementations MAY convert it into `pattern.steps[].events[]` internally for editing or export, but this is **not required** for playback.
+
+#### Runtime scheduling semantics → Steps & NoteEvents
+
+Let `S = meta.stepsPerBar`, `B = pattern.lengthBars` on the same track.
+
+For each **DrumPatternSpec** `{bar = b0, key = k, pattern = P, vel, lengthSteps}`:
+
+1. Resolve `pitch` as `deviceProfile.drumMap[k]` (required).
+2. For each bar offset `t` in `[0 .. repeatBars-1]` while `b = b0 + t ≤ B`:
+   - For each index `s` in `[0 .. S-1]`:
+     - If `P[s] == 'x'`, **schedule a hit** at absolute `Step.idx = (b-1)*S + s` with:
+       - `pitch`: resolved from `drumMap`.
+       - `velocity`: from `vel` (or default if omitted).
+       - `lengthSteps`: from spec’s `lengthSteps` → else `drumKit.lengthSteps` → else `1`.
+
+If multiple specs produce hits at the same `idx` (e.g., kick and clap together), **schedule both hits** at that step. No hits are scheduled for `.`/`-` positions.
+
+#### Constraints & defaults
+
+- The track MUST define `pattern.lengthBars`.
+- Each `pattern` string MUST be exactly `meta.stepsPerBar` chars.
+- `key` MUST exist in `deviceProfile.drumMap`.
+- Default velocity if unspecified MAY be `100`.
+- Default `lengthSteps` if unspecified is `1`.
+
+#### Example — authoring (compact; engine reads `drumKit` directly)
+
+**Authoring (compact, single track)**
+```json
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 112, "ppq": 96, "stepsPerBar": 16, "swing": 0.10 },
+  "deviceProfile": {
+    "portName": "OP-XY",
+    "drumMap": { "kick": 36, "snare": 38, "clap": 39, "ch": 42, "oh": 46 }
+  },
+  "tracks": [
+    {
+      "id": "t-drums",
+      "name": "Drums (one-track)",
+      "type": "sampler",
+      "midiChannel": 0,
+      "role": "drums",
+      "drumKit": {
+        "patterns": [
+          { "bar": 1, "key": "kick", "pattern": "x...x...x...x...", "vel": 120 },
+          { "bar": 1, "key": "clap", "pattern": "..x...x...x...x.", "vel": 102 },
+          { "bar": 1, "key": "ch",   "pattern": ".x.x.x.x.x.x.x.x", "vel": 80  },
+          { "bar": 1, "key": "oh",   "pattern": "................", "vel": 95  }
+        ],
+        "repeatBars": 8,
+        "lengthSteps": 1
+      },
+      "pattern": { "lengthBars": 8, "steps": [] }
+    }
+  ]
+}
+```
+
+
+## 6. Continuous Controller (CC) lanes
+
+Use **ccLanes** to schedule CC automation over time (e.g., filter cutoff, resonance, sends). Destination names must match the OP‑XY’s fixed CC mapping known by the runtime.
+
+### 6.1 CCLane object
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **id** | string | Yes | Lane identifier (e.g., `"cutoff-sweep"`). |
+| **dest** | string \| integer | Yes | Destination CC: `cc:<number>` or `name:<identifier>` resolved by the runtime. |
+| **channel** | integer 0–15 | No | Overrides the track’s channel for this lane. |
+| **mode** | "points" \| "hold" \| "ramp" | Yes | Interpolation/emit behavior. |
+| **points** | array of **CCPoint** | Yes | Defines the curve; points are sorted by time. |
+| **range** | `[number, number]` | No | Clamp CC values (default `[0,127]`). |
+
+**CCPoint** (time/value pair):  
+`{ "t": { "ticks": number } | { "bar": number, "step": number }, "v": 0–127, "curve": "linear"|"exp"|"log"|"s-curve" }`.
+
+---
+
+## 7. Low‑Frequency Oscillators (LFOs)
+
+Runtime‑generated periodic modulation (distinct from explicit CC points).
+
+### 7.1 LFO object
+
+| Key | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| **id** | string | Yes | LFO identifier (e.g., `"cutoff-wobble"`). |
+| **dest** | string \| integer | Yes | Destination controller (same formats as CC lanes). |
+| **channel** | integer 0–15 | No | Defaults to the track’s channel. |
+| **depth** | integer 0–127 | Yes | Peak‑to‑peak amplitude. |
+| **rate** | object | Yes | `{"sync": "1/4"|"1/8"|"1/16"|...}` or `{"hz": number}`. Triplets use `"T"` suffix. |
+| **phase** | number 0–1 | No | Initial phase offset. |
+| **offset** | integer 0–127 | No | Baseline value around which the LFO oscillates. |
+| **shape** | "sine" \| "triangle" \| "saw" \| "ramp" \| "square" \| "samplehold" | Yes | Waveform. |
+| **fadeMs** | integer ≥ 0 | No | Fade‑in time (ms). |
+| **on** | array of windows | No | Active windows: `{ "from": TickRef, "to": TickRef }`. |
+| **stereoSpread** | number 0–1 | No | Phase offset for L/R automation when applicable. |
+
+---
+
+## 8. Additional notes & guidance
+
+- **Engine enumeration:** Track `type` must match an OP‑XY engine (`"sampler"`, `"multiSampler"`, `"axis"`, `"dissolve"`, etc.).  
+- **Sparse steps:** Omit silent indices in `steps`; the array is intentionally sparse.  
+- **Probability & ratchets:** If both are present, probability applies to the entire ratcheted group.  
+- **Tonal context:** When using degrees or relative chord numerals, set `meta.key` and `meta.mode` so the runtime can resolve to MIDI pitches. Absolute pitches/symbols require no tonal context.  
+- **Fixed CC mapping:** Destination names (e.g., `name:cutoff`) are resolved by the runtime against the OP‑XY’s fixed CC map; do **not** embed a `ccMap` in JSON.  
+- **No time‑signature changes:** This schema doesn’t encode time‑signature changes; the OP‑XY handles its own meter.
+
+---
+
+## 9. Quick‑start examples
+
+### 9.1 Minimal drum loop
+
+```json
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 120, "ppq": 480, "stepsPerBar": 16 },
+  "deviceProfile": {
+    "portName": "OP-XY",
+    "drumMap": { "kick": 36, "snare": 38, "ch": 42, "oh": 46 }
+  },
+  "tracks": [
+    {
+      "id": "t-drum",
+      "name": "Drums",
+      "type": "sampler",
+      "midiChannel": 9,
+      "role": "drums",
+      "pattern": {
+        "lengthBars": 1,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 36, "lengthSteps": 2, "velocity": 112 }] },
+          { "idx": 4,  "events": [{ "pitch": 38, "lengthSteps": 2, "velocity": 104 }] },
+          { "idx": 8,  "events": [{ "pitch": 36, "lengthSteps": 2, "velocity": 112, "ratchet": 2 }] },
+          { "idx": 12, "events": [{ "pitch": 38, "lengthSteps": 2, "velocity": 104, "prob": 0.8 }] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### 9.2 Degree‑based bass in C Dorian
+
+```json
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 100, "ppq": 480, "stepsPerBar": 16, "key": "C", "mode": "dorian" },
+  "tracks": [
+    {
+      "id": "t-bass",
+      "name": "Bass",
+      "type": "axis",
+      "midiChannel": 1,
+      "role": "bass",
+      "pattern": {
+        "lengthBars": 2,
+        "steps": [
+          { "idx": 0,  "events": [{ "degree": 1, "octaveOffset": -2, "lengthSteps": 4, "velocity": 108 }] },
+          { "idx": 4,  "events": [{ "degree": 5, "octaveOffset": -2, "lengthSteps": 4, "velocity": 108 }] },
+          { "idx": 8,  "events": [{ "degree": 6, "octaveOffset": -2, "lengthSteps": 4, "velocity": 108 }] },
+          { "idx": 12, "events": [{ "degree": 4, "octaveOffset": -2, "lengthSteps": 4, "velocity": 108 }] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### 9.3 Pad using chord symbols with automation
+
+```json
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 96, "ppq": 480, "stepsPerBar": 16, "swing": 0.08, "key": "C", "mode": "ionian" },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t-chords",
+      "name": "Pad",
+      "type": "dissolve",
+      "midiChannel": 0,
+      "role": "pad",
+      "pattern": {
+        "lengthBars": 2,
+        "steps": [
+          { "idx": 0,  "events": [{ "chord": "Imaj7", "lengthSteps": 8, "velocity": 96, "invert": 1, "register": ["C3","B4"] }] },
+          { "idx": 8,  "events": [{ "chord": "V7",    "lengthSteps": 8, "velocity": 96, "rollMs": 12 }] }
+        ]
+      },
+      "ccLanes": [
+        {
+          "id": "cutoff-sweep",
+          "dest": "name:cutoff",
+          "mode": "ramp",
+          "points": [
+            { "t": { "bar": 0, "step": 0 },  "v": 40 },
+            { "t": { "bar": 1, "step": 15 }, "v": 100 }
+          ]
+        }
+      ],
+      "lfos": [
+        {
+          "id": "pad-wobble",
+          "dest": "name:resonance",
+          "depth": 18,
+          "rate": { "sync": "1/8T" },
+          "shape": "triangle",
+          "offset": 64
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 9.4 Single‑track drums via `drumKit` helper
+
+See §5.1.2 for schema and semantics. Here’s a minimal one‑bar example that the playback engine reads directly (no pre‑conversion of `drumKit` to `steps` is required):
+
+```json
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 120, "ppq": 480, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY", "drumMap": { "kick": 36, "snare": 38 } },
+  "tracks": [
+    {
+      "id": "t-drums",
+      "name": "Kit",
+      "type": "sampler",
+      "midiChannel": 9,
+      "role": "drums",
+      "drumKit": {
+        "patterns": [
+          { "bar": 1, "key": "kick",  "pattern": "x...x...x...x...", "vel": 112 },
+          { "bar": 1, "key": "snare", "pattern": "....x.......x...", "vel": 104 }
+        ],
+        "repeatBars": 1,
+        "lengthSteps": 1
+      },
+      "pattern": { "lengthBars": 1, "steps": [] }
+    }
+  ]
+}
+```
+
+### 9.5 Minimal role labels example
+
+```json
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 112, "ppq": 96, "stepsPerBar": 16, "swing": 0.10 },
+  "deviceProfile": {
+    "portName": "OP-XY",
+    "drumMap": { "kick": 36, "snare": 38, "clap": 39, "ch": 42, "oh": 46 }
+  },
+  "tracks": [
+    {
+      "id": "t-drums",
+      "name": "Kit + Aux Perc",
+      "type": "sampler",
+      "midiChannel": 0,
+      "role": "drums",
+      "pattern": {
+        "lengthBars": 4,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 36, "velocity": 120, "lengthSteps": 1 }] },
+          { "idx": 6,  "events": [{ "pitch": 39, "velocity": 102, "lengthSteps": 1 }] },
+          { "idx": 2,  "events": [{ "pitch": 42, "velocity": 80,  "lengthSteps": 1 }] }
+        ]
+      }
+    },
+    {
+      "id": "t-bass",
+      "name": "Sub Bass",
+      "type": "axis",
+      "midiChannel": 1,
+      "role": "bass",
+      "pattern": {
+        "lengthBars": 4,
+        "steps": [
+          { "idx": 0,  "events": [{ "degree": 1, "octaveOffset": -2, "velocity": 110, "lengthSteps": 4 }] },
+          { "idx": 8,  "events": [{ "degree": 5, "octaveOffset": -2, "velocity": 112, "lengthSteps": 4 }] }
+        ]
+      }
+    },
+    {
+      "id": "t-pluck",
+      "name": "Glimmer Pluck",
+      "type": "multiSampler",
+      "midiChannel": 3,
+      "role": "pluck",
+      "pattern": {
+        "lengthBars": 4,
+        "steps": [
+          { "idx": 1,  "events": [{ "degree": 6, "octaveOffset": 1, "velocity": 105, "lengthSteps": 2 }] },
+          { "idx": 5,  "events": [{ "degree": 7, "octaveOffset": 1, "velocity": 103, "lengthSteps": 2 }] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+---
+
+## 10. Validation checklist
+
+- `version` is exactly `"opxyloop-1.0"`.  
+- `meta` includes `tempo`, `ppq`, `stepsPerBar` (and optional `swing`, `key`, `mode`).  
+- Each `track` defines `id`, `name`, `type`, `midiChannel`, and a `pattern`.  
+- Each `Step` provides `idx` and optional `events`/`tuplet`/`mute`.  
+- Each `NoteEvent` has **one of** `pitch` | `degree` | `chord`, plus `lengthSteps` and `velocity`.  
+- If `degree` is used, include `octaveOffset`; if `chord` is used, optional hints may guide voicing/inversion/strum.  
+- Optional `ccLanes`/`lfos` follow their schemas and reference valid destinations.  
+- If a track includes `drumKit`: `patterns[].key` must exist in `deviceProfile.drumMap`; each `patterns[].pattern` length equals `meta.stepsPerBar`; scheduling respects `pattern.lengthBars` and the runtime semantics in §5.1.2.  
+- If a track includes `role`: treat it as **annotation only** (no playback effect). Recommended values include `"drums"`, `"bass"`, `"pad"`, `"pluck"`, `"lead"`, `"keys"`, `"piano"`, `"guitar"`, `"fx"`, `"vox"`; `"drums"` covers both kit and auxiliary percussion.
+
+---
+
+*This spec is intended to be small, explicit, and implementation‑friendly. If you need scenes or arrangements, store each as its own `opxyloop-1.0` document and sequence them in your application logic.*

--- a/docs/prs/0001-initial-docs.md
+++ b/docs/prs/0001-initial-docs.md
@@ -1,0 +1,34 @@
+# PR #1 — Bootstrap Docs and Plan
+
+## Title
+docs: add normative `opxyloop-1.0` spec; author AGENTS.md and PROJECT_PLAN.md; add milestone handoff protocol
+
+## Summary
+- Added `docs/opxyloop-1.0.md` as the authoritative JSON loop spec (persisted from provided attachment).
+- Authored `AGENTS.md` with clear roles for all agents (Vibe Coding Agent, Conductor, Playback Engine, Web UI, Validator, Git Historian, Test Harness) including responsibilities, invariants, APIs, failure modes, KPIs, and runbooks.
+- Authored `PROJECT_PLAN.md` with detailed milestones (M0–M9), early proof points (P0–P3), a robust real‑time playback engine strategy (no look‑ahead, active‑notes ledger, reconciliation, panic), and a rich test harness spec.
+- Added a Progress Log + Handoff protocol to `AGENTS.md` so agents leave precise pickup pointers tied to PROJECT_PLAN milestones.
+
+## Motivation
+Establish a shared, unambiguous foundation that the Conductor, Playback Engine, and UI will align to, minimizing ambiguity and preventing regressions (stuck notes, timing drift) via plan‑first + test‑first approach.
+
+## Scope
+- Docs and plan only. No runtime code changes in this PR.
+
+## Verification
+- `docs/opxyloop-1.0.md` exists and is referenced unconditionally.
+- Cross‑references in `AGENTS.md` and `PROJECT_PLAN.md` point to the spec and to each other (milestones, handoff).
+- Early proof points are enumerated and actionable (fixtures, clock smoke, demo note) for follow‑up PRs.
+
+## Out of Scope / Follow‑ups
+- Scaffold validator/canonicalizer and fixtures (M0).
+- Implement clock smoke tests and demo note (P1/P2).
+- Conductor + Playback Engine skeletons with test harness wiring (M1–M3).
+
+## Checklist
+- [x] References to `docs/opxyloop-1.0.md`
+- [x] Invariants captured (no look‑ahead, note‑off guarantee, external clock priority)
+- [x] WebSocket types captured (inbound/outbound)
+- [x] Milestones with measurable DoD
+- [x] Handoff/Progress Log guidance for agents
+


### PR DESCRIPTION
# PR #1 — Bootstrap Docs and Plan

## Title
docs: add normative `opxyloop-1.0` spec; author AGENTS.md and PROJECT_PLAN.md; add milestone handoff protocol

## Summary
- Added `docs/opxyloop-1.0.md` as the authoritative JSON loop spec (persisted from provided attachment).
- Authored `AGENTS.md` with clear roles for all agents (Vibe Coding Agent, Conductor, Playback Engine, Web UI, Validator, Git Historian, Test Harness) including responsibilities, invariants, APIs, failure modes, KPIs, and runbooks.
- Authored `PROJECT_PLAN.md` with detailed milestones (M0–M9), early proof points (P0–P3), a robust real‑time playback engine strategy (no look‑ahead, active‑notes ledger, reconciliation, panic), and a rich test harness spec.
- Added a Progress Log + Handoff protocol to `AGENTS.md` so agents leave precise pickup pointers tied to PROJECT_PLAN milestones.

## Motivation
Establish a shared, unambiguous foundation that the Conductor, Playback Engine, and UI will align to, minimizing ambiguity and preventing regressions (stuck notes, timing drift) via plan‑first + test‑first approach.

## Scope
- Docs and plan only. No runtime code changes in this PR.

## Verification
- `docs/opxyloop-1.0.md` exists and is referenced unconditionally.
- Cross‑references in `AGENTS.md` and `PROJECT_PLAN.md` point to the spec and to each other (milestones, handoff).
- Early proof points are enumerated and actionable (fixtures, clock smoke, demo note) for follow‑up PRs.

## Out of Scope / Follow‑ups
- Scaffold validator/canonicalizer and fixtures (M0).
- Implement clock smoke tests and demo note (P1/P2).
- Conductor + Playback Engine skeletons with test harness wiring (M1–M3).

## Checklist
- [x] References to `docs/opxyloop-1.0.md`
- [x] Invariants captured (no look‑ahead, note‑off guarantee, external clock priority)
- [x] WebSocket types captured (inbound/outbound)
- [x] Milestones with measurable DoD
- [x] Handoff/Progress Log guidance for agents

