### PR TITLE
M3 – Real-device Velocity A/B Smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,39 @@ play-cc-lfo-internal:
 .PHONY: play-cc-lfo-ch0
 play-cc-lfo-ch0:
 	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-cc-lfo-ch0.json --mode internal --bpm $(BPM) --port "$(PORT)" --metrics $(METRICS)
+
+.PHONY: play-vel-ch0
+play-vel-ch0:
+	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-vel-ch0.json --mode internal --bpm $(BPM) --port "$(PORT)" --loops $(LOOPS)
+
+.PHONY: panic kill-procs kill-ws-port
+panic:
+	@$(PY) -c "from conductor.midi_out import open_mido_output, MidoSink; out=open_mido_output('$(PORT)'); MidoSink(out).panic(); print('panic sent (CC64/120/123)')" || true
+
+kill-procs:
+	@pkill -f "conductor.conductor_server" || true; \
+	pkill -f "conductor.play_local" || true; \
+	pkill -f "tools/wsctl.py" || true; \
+	printf "done\n"
+
+kill-ws-port:
+	@pids=$$(lsof -t -iTCP:8765 -sTCP:LISTEN 2>/dev/null || true); if [ -n "$$pids" ]; then echo "killing WS PIDs: $$pids"; kill $$pids || true; sleep 1; kill -9 $$pids || true; else echo "no WS listener on 8765"; fi
+.PHONY: play-vel-shaker
+play-vel-shaker:
+	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-vel-shaker.json --mode internal --bpm $(BPM) --port "$(PORT)" --loops $(LOOPS)
+
+.PHONY: play-vel-ab-ch0
+play-vel-ab-ch0:
+	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-vel-ab-ch0.json --mode internal --bpm $(BPM) --port "$(PORT)" --loops $(LOOPS)
+
+.PHONY: play-vel-ab-ch5
+play-vel-ab-ch5:
+	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-vel-ab-ch4.json --mode internal --bpm $(BPM) --port "$(PORT)" --loops $(LOOPS)
+
+.PHONY: play-vel-ab-ch1-d3
+play-vel-ab-ch1-d3:
+	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-vel-ab-ch1-d3.json --mode internal --bpm $(BPM) --port "$(PORT)" --loops $(LOOPS)
+
+.PHONY: play-vel-alt-ch1-d3
+play-vel-alt-ch1-d3:
+	@$(PY) -m conductor.play_local conductor/tests/fixtures/loop-vel-alt-ch1-d3.json --mode internal --bpm $(BPM) --port "$(PORT)" --loops $(LOOPS)

--- a/conductor/play_local.py
+++ b/conductor/play_local.py
@@ -51,6 +51,11 @@ def run_internal(loop_path: str, port_filter: Optional[str], bpm: float, loops: 
     # Send Start and begin
     out.send(mido.Message("start"))
     eng.start()
+    # Process tick 0 immediately so step-0 events are not missed
+    try:
+        eng.on_tick(eng.tick)
+    except Exception:
+        pass
 
     done = threading.Event()
 
@@ -124,8 +129,16 @@ def run_external(loop_path: str, port_filter: Optional[str]):
         try:
             if msg.type == "start":
                 eng.start()
+                try:
+                    eng.on_tick(eng.tick)
+                except Exception:
+                    pass
             elif msg.type == "continue":
                 eng.start()  # same as start for MVP
+                try:
+                    eng.on_tick(eng.tick)
+                except Exception:
+                    pass
             elif msg.type == "stop":
                 eng.stop()
             elif msg.type == "songpos":

--- a/conductor/tests/fixtures/loop-vel-ab-ch0.json
+++ b/conductor/tests/fixtures/loop-vel-ab-ch0.json
@@ -1,0 +1,23 @@
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 100, "ppq": 96, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t1",
+      "name": "Vel AB Ch0",
+      "type": "sampler",
+      "midiChannel": 0,
+      "pattern": {
+        "lengthBars": 1,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 4,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 8,  "events": [{ "pitch": 60, "velocity": 40,  "lengthSteps": 1 }] },
+          { "idx": 12, "events": [{ "pitch": 60, "velocity": 40,  "lengthSteps": 1 }] }
+        ]
+      }
+    }
+  ]
+}
+

--- a/conductor/tests/fixtures/loop-vel-ab-ch1-d3.json
+++ b/conductor/tests/fixtures/loop-vel-ab-ch1-d3.json
@@ -1,0 +1,23 @@
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 100, "ppq": 96, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t1",
+      "name": "Vel AB Ch1 D3",
+      "type": "sampler",
+      "midiChannel": 0,
+      "pattern": {
+        "lengthBars": 1,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 62, "velocity": 127, "lengthSteps": 4 }] },
+          { "idx": 4,  "events": [{ "pitch": 62, "velocity": 127, "lengthSteps": 4 }] },
+          { "idx": 8,  "events": [{ "pitch": 62, "velocity": 40,  "lengthSteps": 4 }] },
+          { "idx": 12, "events": [{ "pitch": 62, "velocity": 40,  "lengthSteps": 4 }] }
+        ]
+      }
+    }
+  ]
+}
+

--- a/conductor/tests/fixtures/loop-vel-ab-ch4.json
+++ b/conductor/tests/fixtures/loop-vel-ab-ch4.json
@@ -1,0 +1,23 @@
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 100, "ppq": 96, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t5",
+      "name": "Vel AB Track5",
+      "type": "sampler",
+      "midiChannel": 4,
+      "pattern": {
+        "lengthBars": 2,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 60, "velocity": 127, "lengthSteps": 8 }] },
+          { "idx": 8,  "events": [{ "pitch": 60, "velocity": 127, "lengthSteps": 8 }] },
+          { "idx": 16, "events": [{ "pitch": 60, "velocity": 1,   "lengthSteps": 8 }] },
+          { "idx": 24, "events": [{ "pitch": 60, "velocity": 1,   "lengthSteps": 8 }] }
+        ]
+      }
+    }
+  ]
+}
+

--- a/conductor/tests/fixtures/loop-vel-alt-ch1-d3.json
+++ b/conductor/tests/fixtures/loop-vel-alt-ch1-d3.json
@@ -1,0 +1,23 @@
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 100, "ppq": 96, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t1",
+      "name": "Vel Alt Ch1 D3",
+      "type": "sampler",
+      "midiChannel": 0,
+      "pattern": {
+        "lengthBars": 2,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 62, "velocity": 127, "lengthSteps": 4 }] },
+          { "idx": 8,  "events": [{ "pitch": 62, "velocity": 10,  "lengthSteps": 4 }] },
+          { "idx": 12, "events": [{ "pitch": 62, "velocity": 127, "lengthSteps": 4 }] },
+          { "idx": 24, "events": [{ "pitch": 62, "velocity": 10,  "lengthSteps": 4 }] }
+        ]
+      }
+    }
+  ]
+}
+

--- a/conductor/tests/fixtures/loop-vel-ch0.json
+++ b/conductor/tests/fixtures/loop-vel-ch0.json
@@ -1,0 +1,23 @@
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 90, "ppq": 96, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t1",
+      "name": "VelocityTest",
+      "type": "sampler",
+      "midiChannel": 0,
+      "pattern": {
+        "lengthBars": 1,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 4,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 8,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 12, "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 1 }] }
+        ]
+      }
+    }
+  ]
+}
+

--- a/conductor/tests/fixtures/loop-vel-shaker.json
+++ b/conductor/tests/fixtures/loop-vel-shaker.json
@@ -1,0 +1,23 @@
+{
+  "version": "opxyloop-1.0",
+  "meta": { "tempo": 100, "ppq": 96, "stepsPerBar": 16 },
+  "deviceProfile": { "portName": "OP-XY" },
+  "tracks": [
+    {
+      "id": "t-drums",
+      "name": "Shaker Velocity AB",
+      "type": "sampler",
+      "midiChannel": 9,
+      "pattern": {
+        "lengthBars": 1,
+        "steps": [
+          { "idx": 0,  "events": [{ "pitch": 82, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 4,  "events": [{ "pitch": 82, "velocity": 110, "lengthSteps": 1 }] },
+          { "idx": 8,  "events": [{ "pitch": 82, "velocity": 40,  "lengthSteps": 1 }] },
+          { "idx": 12, "events": [{ "pitch": 82, "velocity": 40,  "lengthSteps": 1 }] }
+        ]
+      }
+    }
+  ]
+}
+

--- a/tools/panic.py
+++ b/tools/panic.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+from conductor.midi_out import open_mido_output, MidoSink
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Send All Notes Off / All Sound Off to device")
+    ap.add_argument("--port", required=True, help="Substring to match MIDI port (e.g., 'OP-XY')")
+    args = ap.parse_args()
+    out = open_mido_output(args.port)
+    MidoSink(out).panic()
+    print("panic sent (CC64/120/123)")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Adds simple velocity-only smoke tests for OP-XY.\n\n- Fixtures: \n  - loop-vel-ab-ch1-d3.json (Ch1 D3, 127/40)\n  - loop-vel-alt-ch1-d3.json (Ch1 D3, 127/rest/10 alternation)\n  - loop-vel-ab-ch4.json (Ch5 half-notes 127 then 1)\n- Make targets: play-vel-ab-ch1-d3, play-vel-alt-ch1-d3, play-vel-ab-ch5, play-vel-shaker\n- Runtime: process tick 0 on Play to ensure step-0 notes always sound\n- Make: panic/kill targets for clean-slate runs\n\nVerify:\n- make test (13 tests green)\n- Clean slate: make kill-procs && make kill-ws-port && make panic PORT='OP-XY'\n- Run: make play-vel-alt-ch1-d3 PORT='OP-XY' BPM=100 LOOPS=1\n  Listen: loud (127), rest, quiet (10), loud, rest, quiet; stops cleanly.\n\nIncludes AGENTS.md guidance to always stop processes and send panic before new device tests.