### PR TITLE
UI External Clock + CC80 Tempo Control + Pattern View

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,10 @@ Policy:
 - Always include `Verify:` commands in Progress Log entries and record the pass result (e.g., `make test`, specialized harness checks).
 - If a test is flaky, treat it as failing; reduce flakiness (tolerances, fake time) or fix root cause before marking done.
 - For runtime changes, include a minimal demo command (e.g., `make demo-note`) that proves behavior alongside unit tests.
+-### External Clock + Tempo Control
+- Device is tempo master by default. Conductor listens to MIDI Start/Stop/Continue/SPP/Clock; UI displays BPM derived from external pulses.
+- UI tempo changes use CC80 on channel 0, mapped 0..127 → 40..220 BPM; no clock-source switching. This avoids jitter and preserves device control.
+- UI behavior:
+  - BPM field: auto-updates from device (not while focused).
+  - Push tempo: sends CC80 (device remains master).
+  - Play/Stop/Continue: transport only; no tempo pulses are pushed when external.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog – UI External Clock + CC80 Tempo
+
+## Added
+- Web UI (Safari) to view patterns per track and control transport/tempo.
+- External clock support: Conductor listens to OP‑XY MIDI Start/Stop/Continue/SPP/Clock; UI shows device BPM in real time.
+- Tempo control via MIDI CC80 on channel 0 (0..127 → 40..220 BPM). Device remains master; no clock takeover.
+- Velocity A/B smoke fixtures and Make targets (Channel 1 D3 alternating loud/quiet with rests).
+- Panic/kill helpers for clean real-device runs.
+
+## Changed
+- Runtime triggers tick 0 on Play to avoid missing step-0 events.
+- WS server broadcasts state regularly; UI auto-polls as fallback for external BPM.
+
+## How to verify
+- Clean slate: kill processes, free 8765, send panic (see AGENTS.md Real Device Safety).
+- Run Conductor (external clock) and open UI: tempo follows device changes.
+- In UI, type BPM and Push tempo: device BPM changes; device knob remains responsive.
+- Run velocity A/B: loud, rest, quiet, loud, rest, quiet; stops cleanly.
+

--- a/conductor/tempo_map.py
+++ b/conductor/tempo_map.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+def bpm_to_cc80(bpm: float) -> int:
+    """Map BPM in [40, 220] to CC80 value 0..127 (inclusive)."""
+    b = max(40.0, min(220.0, float(bpm)))
+    # 0 -> 40, 127 -> 220; linear mapping
+    val = int(round((b - 40.0) / 180.0 * 127.0))
+    return max(0, min(127, val))
+
+
+def cc80_to_bpm(val: int) -> float:
+    """Map CC80 value 0..127 back to BPM in [40, 220]."""
+    v = max(0, min(127, int(val)))
+    return 40.0 + (v / 127.0) * 180.0
+

--- a/conductor/tests/test_tempo_map.py
+++ b/conductor/tests/test_tempo_map.py
@@ -1,0 +1,18 @@
+import unittest
+
+from conductor.tempo_map import bpm_to_cc80, cc80_to_bpm
+
+
+class TestTempoMap(unittest.TestCase):
+    def test_endpoints(self):
+        self.assertEqual(bpm_to_cc80(40), 0)
+        self.assertEqual(bpm_to_cc80(220), 127)
+        self.assertEqual(bpm_to_cc80(20), 0)   # clamp low
+        self.assertEqual(bpm_to_cc80(300), 127)  # clamp high
+
+    def test_roundtrip_mid(self):
+        # Midpoint around 130 BPM should round to near 130 after mapping back
+        cc = bpm_to_cc80(130)
+        bpm = cc80_to_bpm(cc)
+        self.assertTrue(129.0 <= bpm <= 131.5)
+

--- a/ui/index.html
+++ b/ui/index.html
@@ -31,7 +31,7 @@
       <button id="btnStop">Stop</button>
       <button id="btnCont">Continue</button>
       <label>BPM <input id="bpm" type="number" value="100" min="20" max="300" /></label>
-      <button id="btnTempo">Set Tempo</button>
+      <button id="btnPushTempo">Push tempo</button>
       <span id="status"></span>
     </div>
 
@@ -51,6 +51,8 @@
         ws.onmessage = (ev) => {
           try { const msg = JSON.parse(ev.data); handle(msg); } catch {}
         };
+        // Fallback poll: request state every 1s in case server isn't pushing
+        setInterval(() => { try { ws && ws.readyState === 1 && ws.send(JSON.stringify({type:'getState'})); } catch(e){} }, 1000);
       }
 
       function handle(msg) {
@@ -61,9 +63,16 @@
 
       function renderState() {
         if (!lastState) return;
-        const { transport, bpm, barBeatTick } = lastState;
+        const { transport, bpm, barBeatTick, clockSource } = lastState;
         const bbt = barBeatTick ? ` beat=${barBeatTick.beat} tickInBar=${barBeatTick.tickInBar}/${barBeatTick.barTicks}` : '';
-        setStatus(`transport=${transport} bpm=${bpm}${bbt}`);
+        setStatus(`clock=${clockSource||'internal'} transport=${transport} bpm=${bpm}${bbt}`);
+        // Reflect external tempo changes in the BPM input as well
+        const bpmInput = document.getElementById('bpm');
+        // Do not clobber user's typing when the field has focus
+        if (bpm && bpmInput && document.activeElement !== bpmInput) {
+          bpmInput.value = (Math.round(bpm * 10) / 10).toFixed(1);
+        }
+        // (no clock toggle button in simplified UI)
       }
 
       function renderDoc() {
@@ -126,13 +135,16 @@
       document.getElementById('btnPlay').onclick = () => ws && ws.send(JSON.stringify({type:'play'}));
       document.getElementById('btnStop').onclick = () => ws && ws.send(JSON.stringify({type:'stop'}));
       document.getElementById('btnCont').onclick = () => ws && ws.send(JSON.stringify({type:'continue'}));
-      document.getElementById('btnTempo').onclick = () => {
-        const bpm = parseFloat(document.getElementById('bpm').value||'120');
-        ws && ws.send(JSON.stringify({type:'setTempo', bpm}));
+      // Simplified: Push tempo sends CC80 mapping; device remains master
+      document.getElementById('btnPushTempo').onclick = () => {
+        if (!ws || ws.readyState !== 1) return;
+        const bpmField = document.getElementById('bpm');
+        const bpm = parseFloat(bpmField.value||'120');
+        if (!isFinite(bpm) || bpm <= 0) return;
+        ws.send(JSON.stringify({type:'setTempoCC', bpm}));
       };
 
       connect();
     </script>
   </body>
   </html>
-


### PR DESCRIPTION
This PR documents and ships the Web UI + external clock + CC80 tempo push flow.\n\nHighlights:\n- UI pattern visualization and transport controls\n- External clock (device master) with smoothed BPM display\n- Tempo push via CC80 (0..127 -> 40..220 BPM), no clock takeover\n- Velocity A/B real-device smoke\n- Panic/kill helpers; tick-0 scheduling fix\n\nVerify:\n- Clean slate: kill/port free/panic per AGENTS.md\n- Conductor external + UI open: device BPM updates in UI automatically\n- UI Push tempo changes device tempo; device remains master\n- Velocity A/B sounds as described\n\nNotes:\n- Future: device profile to make CC/channel configurable; minor UI polish