### PR TITLE
Create RL Grime inspired trap loop

### DIFF
--- a/loop.json
+++ b/loop.json
@@ -1,225 +1,10286 @@
 {
   "version": "opxyloop-1.0",
-  "meta": { "tempo": 120, "ppq": 96, "stepsPerBar": 16 },
-  "deviceProfile": { "portName": "OP-XY" },
+  "meta": {
+    "tempo": 140,
+    "ppq": 96,
+    "stepsPerBar": 16,
+    "swing": 0.52,
+    "key": "C",
+    "mode": "minor"
+  },
+  "deviceProfile": {
+    "portName": "OP-XY",
+    "drumMap": {
+      "kick": 53,
+      "snare": 55,
+      "snare_alt": 56,
+      "clap": 58,
+      "rim": 57,
+      "closed_hat": 61,
+      "open_hat": 62,
+      "low_tom": 65,
+      "mid_tom": 67,
+      "crash": 66,
+      "metal": 75
+    }
+  },
   "tracks": [
     {
-      "id": "t5-auto",
-      "name": "OP-XY Track 5 Automation",
-      "type": "axis",
-      "midiChannel": 4,
-      "role": "keys",
+      "id": "t1-drums",
+      "name": "Trap Kit",
+      "type": "sampler",
+      "midiChannel": 9,
+      "role": "drums",
       "pattern": {
-        "lengthBars": 29,
+        "lengthBars": 32,
         "steps": [
-          { "idx": 0,    "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 16,   "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 32,   "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 48,   "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 64,   "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 80,   "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 96,   "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 112,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 128,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 144,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 160,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 176,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 192,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 208,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 224,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 240,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 256,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 272,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 288,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 304,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 320,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 336,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 352,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 368,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 384,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 400,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 416,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] },
-          { "idx": 432,  "events": [{ "pitch": 60, "velocity": 110, "lengthSteps": 16 }] }
+          {
+            "idx": 0,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 118,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 78,
+                "lengthSteps": 8
+              }
+            ]
+          },
+          {
+            "idx": 4,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 102,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 8,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 112,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 96,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 12,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 110,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 16,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 116,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 20,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 98,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 23,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 62,
+                "lengthSteps": 1,
+                "microshiftMs": -12
+              }
+            ]
+          },
+          {
+            "idx": 24,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 111,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 30,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 104,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 31,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": -6
+              }
+            ]
+          },
+          {
+            "idx": 32,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 118,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 36,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 106,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 40,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 113,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 97,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 44,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 108,
+                "lengthSteps": 3,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 46,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 98,
+                "lengthSteps": 1,
+                "microshiftMs": -4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 48,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 115,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 50,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 88,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 52,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 103,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 56,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 112,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 95,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 60,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 109,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 62,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": -3,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 64,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 119,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 68,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 107,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 72,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 114,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 96,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 78,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 104,
+                "lengthSteps": 3,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 80,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 116,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 84,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 105,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 88,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 112,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 95,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 92,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 110,
+                "lengthSteps": 3,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 95,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 96,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 120,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 100,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 102,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 104,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 113,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              },
+              {
+                "pitch": 58,
+                "velocity": 96,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 108,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 111,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 110,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 100,
+                "lengthSteps": 2,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 112,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 118,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 84,
+                "lengthSteps": 10,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 116,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 105,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 120,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 114,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 97,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 124,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 112,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 126,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 96,
+                "lengthSteps": 2,
+                "microshiftMs": -2,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 128,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 114,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 74,
+                "lengthSteps": 8
+              }
+            ]
+          },
+          {
+            "idx": 132,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 98,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 136,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 108,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 92,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 140,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 106,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 144,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 112,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 148,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 151,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 58,
+                "lengthSteps": 1,
+                "microshiftMs": -12
+              }
+            ]
+          },
+          {
+            "idx": 152,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 107,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 90,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 158,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 100,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 159,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": -6
+              }
+            ]
+          },
+          {
+            "idx": 160,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 114,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 164,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 102,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 168,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 109,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 93,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 172,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 104,
+                "lengthSteps": 3,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 174,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 94,
+                "lengthSteps": 1,
+                "microshiftMs": -4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 176,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 111,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 178,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 180,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 99,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 184,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 108,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 91,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 188,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 105,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 190,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 90,
+                "lengthSteps": 2,
+                "microshiftMs": -3,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 192,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 115,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 196,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 103,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 200,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 110,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 92,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 206,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 100,
+                "lengthSteps": 3,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 208,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 112,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 212,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 101,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 216,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 108,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 91,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 220,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 106,
+                "lengthSteps": 3,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 223,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 64,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 224,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 116,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 228,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 98,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 232,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 109,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              },
+              {
+                "pitch": 58,
+                "velocity": 92,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 236,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 107,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 238,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 96,
+                "lengthSteps": 2,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 240,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 114,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 88,
+                "lengthSteps": 10,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 244,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 101,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 248,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 110,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 93,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 252,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 108,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 254,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 92,
+                "lengthSteps": 2,
+                "microshiftMs": -2,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 255,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 102,
+                "lengthSteps": 2,
+                "ratchet": 4,
+                "microshiftMs": -6
+              }
+            ]
+          },
+          {
+            "idx": 256,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 121,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 81,
+                "lengthSteps": 8
+              }
+            ]
+          },
+          {
+            "idx": 260,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 105,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 264,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 115,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 99,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 268,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 113,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 272,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 119,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 276,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 101,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 279,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": -12
+              }
+            ]
+          },
+          {
+            "idx": 280,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 114,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 97,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 286,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 107,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 287,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -6
+              }
+            ]
+          },
+          {
+            "idx": 288,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 121,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 292,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 109,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 296,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 116,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 100,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 300,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 111,
+                "lengthSteps": 3,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 302,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 101,
+                "lengthSteps": 1,
+                "microshiftMs": -4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 304,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 118,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 306,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 91,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 308,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 106,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 312,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 115,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 98,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 316,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 112,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 318,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 97,
+                "lengthSteps": 2,
+                "microshiftMs": -3,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 320,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 122,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 324,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 110,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 328,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 117,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 99,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 334,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 107,
+                "lengthSteps": 3,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 336,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 119,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 340,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 108,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 344,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 115,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 98,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 348,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 113,
+                "lengthSteps": 3,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 351,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 352,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 123,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 356,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 105,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 360,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 116,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              },
+              {
+                "pitch": 58,
+                "velocity": 99,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 364,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 114,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 366,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 103,
+                "lengthSteps": 2,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 368,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 121,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 92,
+                "lengthSteps": 10,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 372,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 108,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 376,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 117,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 100,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 380,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 115,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 382,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 99,
+                "lengthSteps": 2,
+                "microshiftMs": -2,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 383,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 102,
+                "lengthSteps": 2,
+                "ratchet": 4,
+                "microshiftMs": -6
+              }
+            ]
+          },
+          {
+            "idx": 384,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 116,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 76,
+                "lengthSteps": 8
+              }
+            ]
+          },
+          {
+            "idx": 388,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 100,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 392,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 110,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 396,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 108,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 400,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 114,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 404,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 96,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 407,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 60,
+                "lengthSteps": 1,
+                "microshiftMs": -12
+              }
+            ]
+          },
+          {
+            "idx": 408,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 109,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 92,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 414,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 102,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 415,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": -6
+              }
+            ]
+          },
+          {
+            "idx": 416,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 116,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 420,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 104,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 424,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 111,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 95,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 428,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 106,
+                "lengthSteps": 3,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 430,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 96,
+                "lengthSteps": 1,
+                "microshiftMs": -4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 432,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 113,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 434,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 86,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 436,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 101,
+                "lengthSteps": 2,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 440,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 110,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 93,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 444,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 107,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 446,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 92,
+                "lengthSteps": 2,
+                "microshiftMs": -3,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 448,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 117,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 452,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 105,
+                "lengthSteps": 3,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 456,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 112,
+                "lengthSteps": 2,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 58,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 462,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 102,
+                "lengthSteps": 3,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 464,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 114,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 468,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 103,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 472,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 110,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 93,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 476,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 108,
+                "lengthSteps": 3,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 479,
+            "events": [
+              {
+                "pitch": 57,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              }
+            ]
+          },
+          {
+            "idx": 480,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 118,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 484,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 100,
+                "lengthSteps": 2,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 488,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 111,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              },
+              {
+                "pitch": 58,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 492,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 109,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 494,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 98,
+                "lengthSteps": 2,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 496,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 116,
+                "lengthSteps": 3
+              },
+              {
+                "pitch": 66,
+                "velocity": 96,
+                "lengthSteps": 10,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 500,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 103,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 504,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 112,
+                "lengthSteps": 2,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 58,
+                "velocity": 95,
+                "lengthSteps": 2,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 508,
+            "events": [
+              {
+                "pitch": 53,
+                "velocity": 110,
+                "lengthSteps": 3
+              }
+            ]
+          },
+          {
+            "idx": 510,
+            "events": [
+              {
+                "pitch": 56,
+                "velocity": 94,
+                "lengthSteps": 2,
+                "microshiftMs": -2,
+                "ratchet": 3
+              }
+            ]
+          },
+          {
+            "idx": 511,
+            "events": [
+              {
+                "pitch": 55,
+                "velocity": 102,
+                "lengthSteps": 2,
+                "ratchet": 4,
+                "microshiftMs": -6
+              }
+            ]
+          }
         ]
       },
       "ccLanes": [
-        { "id": "b01-track_volume", "dest": "name:track_volume", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "linear" },
-          { "t": { "bar": 0,  "step": 0 },  "v": 30, "curve": "linear" },
-          { "t": { "bar": 0,  "step": 15 }, "v": 110, "curve": "linear" },
-          { "t": { "bar": 1,  "step": 0 },  "v": 64, "curve": "linear" }
-        ]},
-        { "id": "b02-track_mute", "dest": "name:track_mute", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 1,  "step": 0 },  "v": 30 },
-          { "t": { "bar": 1,  "step": 15 }, "v": 110 },
-          { "t": { "bar": 2,  "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b03-track_pan", "dest": "name:track_pan", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "s-curve" },
-          { "t": { "bar": 2,  "step": 0 },  "v": 30, "curve": "s-curve" },
-          { "t": { "bar": 2,  "step": 15 }, "v": 110, "curve": "s-curve" },
-          { "t": { "bar": 3,  "step": 0 },  "v": 64, "curve": "s-curve" }
-        ]},
-        { "id": "b04-param1", "dest": "name:param1", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "exp" },
-          { "t": { "bar": 3,  "step": 0 },  "v": 30, "curve": "exp" },
-          { "t": { "bar": 3,  "step": 15 }, "v": 110, "curve": "exp" },
-          { "t": { "bar": 4,  "step": 0 },  "v": 64, "curve": "exp" }
-        ]},
-        { "id": "b05-param2", "dest": "name:param2", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "log" },
-          { "t": { "bar": 4,  "step": 0 },  "v": 30, "curve": "log" },
-          { "t": { "bar": 4,  "step": 15 }, "v": 110, "curve": "log" },
-          { "t": { "bar": 5,  "step": 0 },  "v": 64, "curve": "log" }
-        ]},
-        { "id": "b06-param3", "dest": "name:param3", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 5,  "step": 0 },  "v": 30 },
-          { "t": { "bar": 5,  "step": 15 }, "v": 110 },
-          { "t": { "bar": 6,  "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b07-param4", "dest": "name:param4", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 6,  "step": 0 },  "v": 30 },
-          { "t": { "bar": 6,  "step": 15 }, "v": 110 },
-          { "t": { "bar": 7,  "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b08-amp_attack", "dest": "name:amp_attack", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "s-curve" },
-          { "t": { "bar": 7,  "step": 0 },  "v": 30, "curve": "s-curve" },
-          { "t": { "bar": 7,  "step": 15 }, "v": 110, "curve": "s-curve" },
-          { "t": { "bar": 8,  "step": 0 },  "v": 64, "curve": "s-curve" }
-        ]},
-        { "id": "b09-amp_decay", "dest": "name:amp_decay", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 8,  "step": 0 },  "v": 30 },
-          { "t": { "bar": 8,  "step": 15 }, "v": 110 },
-          { "t": { "bar": 9,  "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b10-amp_sustain", "dest": "name:amp_sustain", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 9,  "step": 0 },  "v": 30 },
-          { "t": { "bar": 9,  "step": 15 }, "v": 110 },
-          { "t": { "bar": 10, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b11-amp_release", "dest": "name:amp_release", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 10, "step": 0 },  "v": 30 },
-          { "t": { "bar": 10, "step": 15 }, "v": 110 },
-          { "t": { "bar": 11, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b12-filter_attack", "dest": "name:filter_attack", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "exp" },
-          { "t": { "bar": 11, "step": 0 },  "v": 30, "curve": "exp" },
-          { "t": { "bar": 11, "step": 15 }, "v": 110, "curve": "exp" },
-          { "t": { "bar": 12, "step": 0 },  "v": 64, "curve": "exp" }
-        ]},
-        { "id": "b13-filter_decay", "dest": "name:filter_decay", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 12, "step": 0 },  "v": 30 },
-          { "t": { "bar": 12, "step": 15 }, "v": 110 },
-          { "t": { "bar": 13, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b14-filter_sustain", "dest": "name:filter_sustain", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 13, "step": 0 },  "v": 30 },
-          { "t": { "bar": 13, "step": 15 }, "v": 110 },
-          { "t": { "bar": 14, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b15-filter_release", "dest": "name:filter_release", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 14, "step": 0 },  "v": 30 },
-          { "t": { "bar": 14, "step": 15 }, "v": 110 },
-          { "t": { "bar": 15, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b16-voice_mode", "dest": "name:voice_mode", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "log" },
-          { "t": { "bar": 15, "step": 0 },  "v": 30, "curve": "log" },
-          { "t": { "bar": 15, "step": 15 }, "v": 110, "curve": "log" },
-          { "t": { "bar": 16, "step": 0 },  "v": 64, "curve": "log" }
-        ]},
-        { "id": "b17-portamento", "dest": "name:portamento", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 16, "step": 0 },  "v": 30 },
-          { "t": { "bar": 16, "step": 15 }, "v": 110 },
-          { "t": { "bar": 17, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b18-pitchbend_amount", "dest": "name:pitchbend_amount", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 17, "step": 0 },  "v": 30 },
-          { "t": { "bar": 17, "step": 15 }, "v": 110 },
-          { "t": { "bar": 18, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b19-engine_volume", "dest": "name:engine_volume", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 18, "step": 0 },  "v": 30 },
-          { "t": { "bar": 18, "step": 15 }, "v": 110 },
-          { "t": { "bar": 19, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b20-cutoff", "dest": "name:cutoff", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "s-curve" },
-          { "t": { "bar": 19, "step": 0 },  "v": 30, "curve": "s-curve" },
-          { "t": { "bar": 19, "step": 15 }, "v": 110, "curve": "s-curve" },
-          { "t": { "bar": 20, "step": 0 },  "v": 64, "curve": "s-curve" }
-        ]},
-        { "id": "b21-resonance", "dest": "name:resonance", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "exp" },
-          { "t": { "bar": 20, "step": 0 },  "v": 30, "curve": "exp" },
-          { "t": { "bar": 20, "step": 15 }, "v": 110, "curve": "exp" },
-          { "t": { "bar": 21, "step": 0 },  "v": 64, "curve": "exp" }
-        ]},
-        { "id": "b22-env_amount", "dest": "name:env_amount", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 21, "step": 0 },  "v": 30 },
-          { "t": { "bar": 21, "step": 15 }, "v": 110 },
-          { "t": { "bar": 22, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b23-key_tracking", "dest": "name:key_tracking", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 22, "step": 0 },  "v": 30 },
-          { "t": { "bar": 22, "step": 15 }, "v": 110 },
-          { "t": { "bar": 23, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b24-send_ext", "dest": "name:send_ext", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "log" },
-          { "t": { "bar": 23, "step": 0 },  "v": 30, "curve": "log" },
-          { "t": { "bar": 23, "step": 15 }, "v": 110, "curve": "log" },
-          { "t": { "bar": 24, "step": 0 },  "v": 64, "curve": "log" }
-        ]},
-        { "id": "b25-send_tape", "dest": "name:send_tape", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 24, "step": 0 },  "v": 30 },
-          { "t": { "bar": 24, "step": 15 }, "v": 110 },
-          { "t": { "bar": 25, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b26-send_fx1", "dest": "name:send_fx1", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 25, "step": 0 },  "v": 30 },
-          { "t": { "bar": 25, "step": 15 }, "v": 110 },
-          { "t": { "bar": 26, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b27-send_fx2", "dest": "name:send_fx2", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64, "curve": "s-curve" },
-          { "t": { "bar": 26, "step": 0 },  "v": 30, "curve": "s-curve" },
-          { "t": { "bar": 26, "step": 15 }, "v": 110, "curve": "s-curve" },
-          { "t": { "bar": 27, "step": 0 },  "v": 64, "curve": "s-curve" }
-        ]},
-        { "id": "b28-lfo_dest", "dest": "name:lfo_dest", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 27, "step": 0 },  "v": 30 },
-          { "t": { "bar": 27, "step": 15 }, "v": 110 },
-          { "t": { "bar": 28, "step": 0 },  "v": 64 }
-        ]},
-        { "id": "b29-lfo_param", "dest": "name:lfo_param", "mode": "ramp", "points": [
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 },
-          { "t": { "bar": 28, "step": 0 },  "v": 30 },
-          { "t": { "bar": 28, "step": 15 }, "v": 110 },
-          { "t": { "bar": 0,  "step": 0 },  "v": 64 }
-        ]}
+        {
+          "id": "drums_cutoff",
+          "dest": "name:cutoff",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 58
+            },
+            {
+              "t": {
+                "bar": 13,
+                "step": 8
+              },
+              "v": 72
+            },
+            {
+              "t": {
+                "bar": 27,
+                "step": 0
+              },
+              "v": 45
+            },
+            {
+              "t": {
+                "bar": 41,
+                "step": 0
+              },
+              "v": 80
+            }
+          ]
+        },
+        {
+          "id": "drums_fx1",
+          "dest": "name:send_fx1",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 40
+            },
+            {
+              "t": {
+                "bar": 11,
+                "step": 8
+              },
+              "v": 68
+            },
+            {
+              "t": {
+                "bar": 25,
+                "step": 0
+              },
+              "v": 52
+            },
+            {
+              "t": {
+                "bar": 38,
+                "step": 0
+              },
+              "v": 76
+            }
+          ]
+        },
+        {
+          "id": "drums_fx2",
+          "dest": "name:send_fx2",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 48
+            },
+            {
+              "t": {
+                "bar": 9,
+                "step": 4
+              },
+              "v": 70
+            },
+            {
+              "t": {
+                "bar": 21,
+                "step": 0
+              },
+              "v": 55
+            },
+            {
+              "t": {
+                "bar": 35,
+                "step": 0
+              },
+              "v": 82
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "t2-hats",
+      "name": "Trap Hats",
+      "type": "sampler",
+      "midiChannel": 9,
+      "role": "drums",
+      "pattern": {
+        "lengthBars": 32,
+        "steps": [
+          {
+            "idx": 0,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 1,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 2,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 3,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 4,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 5,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 6,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 7,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 8,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 9,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 10,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 11,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 12,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 13,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 14,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 15,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 16,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 17,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 18,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 19,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 20,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 21,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 22,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 23,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 24,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 25,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 26,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 27,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 28,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 84,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 29,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 30,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 31,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 32,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 33,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 34,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 35,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 36,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 37,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 38,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 39,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 40,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 41,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 42,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 43,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 44,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 45,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 46,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 47,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 48,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 49,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 50,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 51,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 52,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 53,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 54,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 55,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 56,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 57,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 58,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 59,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 60,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 61,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 62,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 63,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 64,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 65,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 66,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 67,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 68,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 69,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 70,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 71,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 72,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 73,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 74,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 75,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 76,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 77,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 78,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 79,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 80,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 81,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 82,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 83,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 84,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 85,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 86,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 87,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 88,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 89,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 90,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 91,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 92,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 85,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 93,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 94,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 95,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 96,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 97,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 63,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 98,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 99,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 100,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 101,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 102,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 103,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 104,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 105,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 106,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 107,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 108,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 109,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 110,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 111,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 112,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 113,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 114,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 115,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 116,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 117,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 118,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 119,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 120,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 121,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 122,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 123,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 124,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 125,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 126,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 61,
+                "velocity": 92,
+                "lengthSteps": 1,
+                "ratchet": 4,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 127,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 128,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 129,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 130,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 131,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 132,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 133,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 134,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 135,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 136,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 137,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 138,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 139,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 140,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 141,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 142,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 143,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 144,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 145,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 146,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 147,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 148,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 149,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 150,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 151,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 152,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 153,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 154,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 155,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 156,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 157,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 158,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 159,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 160,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 161,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 64,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 162,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 163,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 164,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 165,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 166,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 167,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 168,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 169,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 170,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 171,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 172,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 173,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 174,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 175,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 176,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 177,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 178,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 179,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 180,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 181,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 182,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 183,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 184,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 185,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 186,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 187,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 188,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 84,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 189,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 190,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 191,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 192,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 193,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 194,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 195,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 196,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 197,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 198,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 199,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 200,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 201,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 202,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 203,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 204,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 205,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 206,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 207,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 208,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 209,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 210,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 211,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 212,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 213,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 214,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 215,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 216,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 217,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 218,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 219,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 220,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 84,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 221,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 222,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 223,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 224,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 225,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 226,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 227,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 228,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 229,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 230,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 231,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 232,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 233,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 234,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 235,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 236,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 237,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 238,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 239,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 240,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 241,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 242,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 243,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 244,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 245,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 246,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 247,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 248,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 249,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 250,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 251,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 252,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 253,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 254,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 61,
+                "velocity": 92,
+                "lengthSteps": 1,
+                "ratchet": 4,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 255,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 256,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 257,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 258,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 259,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 260,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 261,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 262,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 263,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 264,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 265,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 266,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 267,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 268,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 269,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 270,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 271,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 272,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 273,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 274,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 275,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 276,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 277,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 278,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 279,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 280,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 281,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 282,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 283,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 284,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 85,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 285,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 286,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 287,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 288,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 289,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 63,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 290,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 291,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 292,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 293,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 294,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 295,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 296,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 297,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 298,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 299,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 300,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 301,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 302,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 303,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 304,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 305,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 306,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 307,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 308,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 309,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 310,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 311,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 312,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 313,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 314,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 315,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 316,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 317,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 318,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 319,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 320,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 321,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 322,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 323,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 324,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 325,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 326,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 327,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 328,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 329,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 330,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 331,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 332,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 333,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 334,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 335,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 336,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 337,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 338,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 339,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 340,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 341,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 342,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 343,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 344,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 345,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 346,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 347,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 348,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 349,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 350,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 351,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 352,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 353,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 64,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 354,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 355,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 356,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 357,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 358,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 359,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 360,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 361,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 362,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 363,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 364,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 365,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 366,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 367,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 368,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 369,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 370,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 371,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 372,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 373,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 374,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 375,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 376,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 377,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 378,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 379,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 380,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 84,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 381,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 382,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 61,
+                "velocity": 92,
+                "lengthSteps": 1,
+                "ratchet": 4,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 383,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 384,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 385,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 386,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 387,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 388,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 389,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 390,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 391,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 392,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 393,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 394,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 395,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 396,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 397,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 398,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 399,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 400,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 401,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 402,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 403,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 404,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 405,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 406,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 407,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 408,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 409,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 410,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 411,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 412,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 84,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 413,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 414,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 415,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 416,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 417,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 418,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 419,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 420,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 421,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 422,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 423,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 424,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 425,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 426,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 427,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 428,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 429,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 430,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 431,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 432,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 433,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 434,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 435,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 436,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 437,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 438,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 439,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 440,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 441,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 442,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 443,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 444,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 445,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 446,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 447,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 448,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 449,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 450,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 451,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 452,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 453,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 454,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 455,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 456,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 457,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 458,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 459,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 460,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 62,
+                "velocity": 82,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 461,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 462,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 463,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 464,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 465,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 466,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 467,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 468,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 469,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 470,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 471,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 472,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 473,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 474,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 82,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 475,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 476,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 85,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 62,
+                "velocity": 85,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 477,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 478,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 479,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 2,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 480,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 481,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 63,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 482,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 483,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 65,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 484,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 485,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 67,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 486,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 487,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 488,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 489,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 66,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 490,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 491,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 492,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 78,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 62,
+                "velocity": 80,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 493,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 494,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 495,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 69,
+                "lengthSteps": 1,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 496,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 75,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 497,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 68,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 498,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 499,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 70,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 500,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 79,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 501,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 502,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 86,
+                "lengthSteps": 1,
+                "microshiftMs": -5
+              },
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 72,
+                "lengthSteps": 1,
+                "microshiftMs": 5
+              }
+            ],
+            "tuplet": "triplet"
+          },
+          {
+            "idx": 503,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 504,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 77,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 505,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 71,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 506,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 80,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 507,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 73,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 508,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 83,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 62,
+                "velocity": 84,
+                "lengthSteps": 2,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 509,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 76,
+                "lengthSteps": 1,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 510,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 81,
+                "lengthSteps": 1,
+                "microshiftMs": -1
+              },
+              {
+                "pitch": 61,
+                "velocity": 92,
+                "lengthSteps": 1,
+                "ratchet": 4,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 511,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 74,
+                "lengthSteps": 1,
+                "microshiftMs": 4,
+                "ratchet": 2
+              }
+            ]
+          }
+        ]
+      },
+      "ccLanes": [
+        {
+          "id": "hats_cutoff",
+          "dest": "name:cutoff",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 62
+            },
+            {
+              "t": {
+                "bar": 10,
+                "step": 0
+              },
+              "v": 78
+            },
+            {
+              "t": {
+                "bar": 22,
+                "step": 0
+              },
+              "v": 52
+            },
+            {
+              "t": {
+                "bar": 34,
+                "step": 0
+              },
+              "v": 88
+            },
+            {
+              "t": {
+                "bar": 46,
+                "step": 0
+              },
+              "v": 60
+            }
+          ]
+        },
+        {
+          "id": "hats_fx1",
+          "dest": "name:send_fx1",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 44
+            },
+            {
+              "t": {
+                "bar": 12,
+                "step": 8
+              },
+              "v": 72
+            },
+            {
+              "t": {
+                "bar": 26,
+                "step": 0
+              },
+              "v": 50
+            },
+            {
+              "t": {
+                "bar": 39,
+                "step": 0
+              },
+              "v": 78
+            }
+          ]
+        },
+        {
+          "id": "hats_fx2",
+          "dest": "name:send_fx2",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 52
+            },
+            {
+              "t": {
+                "bar": 14,
+                "step": 0
+              },
+              "v": 76
+            },
+            {
+              "t": {
+                "bar": 28,
+                "step": 0
+              },
+              "v": 58
+            },
+            {
+              "t": {
+                "bar": 42,
+                "step": 0
+              },
+              "v": 86
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "t3-bass",
+      "name": "808 Bass",
+      "type": "axis",
+      "midiChannel": 1,
+      "role": "bass",
+      "pattern": {
+        "lengthBars": 32,
+        "steps": [
+          {
+            "idx": 0,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 118,
+                "lengthSteps": 14
+              }
+            ]
+          },
+          {
+            "idx": 12,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 110,
+                "lengthSteps": 6,
+                "microshiftMs": 1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 16,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 112,
+                "lengthSteps": 12,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 24,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 108,
+                "lengthSteps": 8,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 32,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 116,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 40,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 109,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 46,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 106,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 48,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 112,
+                "lengthSteps": 12,
+                "microshiftMs": -1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 56,
+            "events": [
+              {
+                "pitch": 34,
+                "velocity": 104,
+                "lengthSteps": 6,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 60,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 115,
+                "lengthSteps": 8,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 64,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 117,
+                "lengthSteps": 12,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 72,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 110,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 80,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 112,
+                "lengthSteps": 10,
+                "microshiftMs": -3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 88,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 109,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 96,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 118,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 104,
+            "events": [
+              {
+                "pitch": 38,
+                "velocity": 106,
+                "lengthSteps": 6,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 108,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 108,
+                "lengthSteps": 6,
+                "microshiftMs": 4,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 112,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 113,
+                "lengthSteps": 10,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 120,
+            "events": [
+              {
+                "pitch": 46,
+                "velocity": 109,
+                "lengthSteps": 6,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 124,
+            "events": [
+              {
+                "pitch": 48,
+                "velocity": 107,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 127,
+            "events": [
+              {
+                "pitch": 34,
+                "velocity": 98,
+                "lengthSteps": 3,
+                "ratchet": 2,
+                "microshiftMs": -7
+              }
+            ]
+          },
+          {
+            "idx": 128,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 117,
+                "lengthSteps": 14
+              }
+            ]
+          },
+          {
+            "idx": 140,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 109,
+                "lengthSteps": 6,
+                "microshiftMs": 1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 144,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 111,
+                "lengthSteps": 12,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 152,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 107,
+                "lengthSteps": 8,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 160,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 115,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 168,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 108,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 174,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 105,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 176,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 111,
+                "lengthSteps": 12,
+                "microshiftMs": -1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 184,
+            "events": [
+              {
+                "pitch": 34,
+                "velocity": 103,
+                "lengthSteps": 6,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 188,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 114,
+                "lengthSteps": 8,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 192,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 116,
+                "lengthSteps": 12,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 200,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 109,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 208,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 111,
+                "lengthSteps": 10,
+                "microshiftMs": -3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 216,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 108,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 224,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 117,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 232,
+            "events": [
+              {
+                "pitch": 38,
+                "velocity": 105,
+                "lengthSteps": 6,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 236,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 107,
+                "lengthSteps": 6,
+                "microshiftMs": 4,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 240,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 112,
+                "lengthSteps": 10,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 248,
+            "events": [
+              {
+                "pitch": 46,
+                "velocity": 108,
+                "lengthSteps": 6,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 252,
+            "events": [
+              {
+                "pitch": 48,
+                "velocity": 106,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 255,
+            "events": [
+              {
+                "pitch": 35,
+                "velocity": 100,
+                "lengthSteps": 3,
+                "ratchet": 2,
+                "microshiftMs": -7
+              }
+            ]
+          },
+          {
+            "idx": 256,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 116,
+                "lengthSteps": 14
+              }
+            ]
+          },
+          {
+            "idx": 268,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 108,
+                "lengthSteps": 6,
+                "microshiftMs": 1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 272,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 110,
+                "lengthSteps": 12,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 280,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 106,
+                "lengthSteps": 8,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 288,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 114,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 296,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 107,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 302,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 104,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 304,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 110,
+                "lengthSteps": 12,
+                "microshiftMs": -1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 312,
+            "events": [
+              {
+                "pitch": 34,
+                "velocity": 102,
+                "lengthSteps": 6,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 316,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 113,
+                "lengthSteps": 8,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 320,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 115,
+                "lengthSteps": 12,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 328,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 108,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 336,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 110,
+                "lengthSteps": 10,
+                "microshiftMs": -3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 344,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 107,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 352,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 116,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 360,
+            "events": [
+              {
+                "pitch": 38,
+                "velocity": 104,
+                "lengthSteps": 6,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 364,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 106,
+                "lengthSteps": 6,
+                "microshiftMs": 4,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 368,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 111,
+                "lengthSteps": 10,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 376,
+            "events": [
+              {
+                "pitch": 46,
+                "velocity": 107,
+                "lengthSteps": 6,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 380,
+            "events": [
+              {
+                "pitch": 48,
+                "velocity": 105,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 383,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 102,
+                "lengthSteps": 3,
+                "ratchet": 2,
+                "microshiftMs": -7
+              }
+            ]
+          },
+          {
+            "idx": 384,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 115,
+                "lengthSteps": 14
+              }
+            ]
+          },
+          {
+            "idx": 396,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 107,
+                "lengthSteps": 6,
+                "microshiftMs": 1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 400,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 109,
+                "lengthSteps": 12,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 408,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 105,
+                "lengthSteps": 8,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 416,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 113,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 424,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 106,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 430,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 103,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 432,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 109,
+                "lengthSteps": 12,
+                "microshiftMs": -1,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 440,
+            "events": [
+              {
+                "pitch": 34,
+                "velocity": 101,
+                "lengthSteps": 6,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 444,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 112,
+                "lengthSteps": 8,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 448,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 114,
+                "lengthSteps": 12,
+                "microshiftMs": -1
+              }
+            ]
+          },
+          {
+            "idx": 456,
+            "events": [
+              {
+                "pitch": 39,
+                "velocity": 107,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 464,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 109,
+                "lengthSteps": 10,
+                "microshiftMs": -3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 472,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 106,
+                "lengthSteps": 8,
+                "microshiftMs": 2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 480,
+            "events": [
+              {
+                "pitch": 36,
+                "velocity": 115,
+                "lengthSteps": 16
+              }
+            ]
+          },
+          {
+            "idx": 488,
+            "events": [
+              {
+                "pitch": 38,
+                "velocity": 103,
+                "lengthSteps": 6,
+                "microshiftMs": 3
+              }
+            ]
+          },
+          {
+            "idx": 492,
+            "events": [
+              {
+                "pitch": 41,
+                "velocity": 105,
+                "lengthSteps": 6,
+                "microshiftMs": 4,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 496,
+            "events": [
+              {
+                "pitch": 43,
+                "velocity": 110,
+                "lengthSteps": 10,
+                "microshiftMs": -2,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 504,
+            "events": [
+              {
+                "pitch": 46,
+                "velocity": 106,
+                "lengthSteps": 6,
+                "microshiftMs": 3,
+                "gate": 0.92
+              }
+            ]
+          },
+          {
+            "idx": 508,
+            "events": [
+              {
+                "pitch": 48,
+                "velocity": 104,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              },
+              {
+                "pitch": 48,
+                "velocity": 120,
+                "lengthSteps": 4,
+                "microshiftMs": 3,
+                "ratchet": 2
+              }
+            ]
+          },
+          {
+            "idx": 511,
+            "events": [
+              {
+                "pitch": 37,
+                "velocity": 104,
+                "lengthSteps": 3,
+                "ratchet": 2,
+                "microshiftMs": -7
+              }
+            ]
+          }
+        ]
+      },
+      "ccLanes": [
+        {
+          "id": "bass_cutoff",
+          "dest": "name:cutoff",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 42
+            },
+            {
+              "t": {
+                "bar": 16,
+                "step": 0
+              },
+              "v": 68
+            },
+            {
+              "t": {
+                "bar": 32,
+                "step": 0
+              },
+              "v": 52
+            },
+            {
+              "t": {
+                "bar": 48,
+                "step": 0
+              },
+              "v": 80
+            }
+          ]
+        },
+        {
+          "id": "bass_fx1",
+          "dest": "name:send_fx1",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 30
+            },
+            {
+              "t": {
+                "bar": 18,
+                "step": 0
+              },
+              "v": 58
+            },
+            {
+              "t": {
+                "bar": 36,
+                "step": 0
+              },
+              "v": 44
+            },
+            {
+              "t": {
+                "bar": 54,
+                "step": 0
+              },
+              "v": 68
+            }
+          ]
+        },
+        {
+          "id": "bass_fx2",
+          "dest": "name:send_fx2",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 48
+            },
+            {
+              "t": {
+                "bar": 20,
+                "step": 0
+              },
+              "v": 74
+            },
+            {
+              "t": {
+                "bar": 40,
+                "step": 0
+              },
+              "v": 56
+            },
+            {
+              "t": {
+                "bar": 60,
+                "step": 0
+              },
+              "v": 82
+            }
+          ]
+        },
+        {
+          "id": "bass_port",
+          "dest": "name:portamento",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 90
+            },
+            {
+              "t": {
+                "bar": 24,
+                "step": 0
+              },
+              "v": 100
+            },
+            {
+              "t": {
+                "bar": 48,
+                "step": 0
+              },
+              "v": 88
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "t4-lead",
+      "name": "Brass Lead",
+      "type": "axis",
+      "midiChannel": 2,
+      "role": "lead",
+      "pattern": {
+        "lengthBars": 32,
+        "steps": [
+          {
+            "idx": 0,
+            "events": [
+              {
+                "pitch": 60,
+                "velocity": 102,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 75,
+                "velocity": 112,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              },
+              {
+                "pitch": 73,
+                "velocity": 120,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              }
+            ]
+          },
+          {
+            "idx": 8,
+            "events": [
+              {
+                "pitch": 63,
+                "velocity": 96,
+                "lengthSteps": 4,
+                "microshiftMs": 6
+              },
+              {
+                "pitch": 75,
+                "velocity": 112,
+                "lengthSteps": 4,
+                "microshiftMs": 5
+              }
+            ]
+          },
+          {
+            "idx": 32,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 108,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 70,
+                "velocity": 117,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 44,
+            "events": [
+              {
+                "pitch": 72,
+                "velocity": 104,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 64,
+            "events": [
+              {
+                "pitch": 70,
+                "velocity": 104,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 66,
+                "velocity": 114,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 76,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 98,
+                "lengthSteps": 3,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 96,
+            "events": [
+              {
+                "pitch": 63,
+                "velocity": 106,
+                "lengthSteps": 5,
+                "microshiftMs": 1
+              },
+              {
+                "pitch": 63,
+                "velocity": 112,
+                "lengthSteps": 4,
+                "microshiftMs": -2
+              }
+            ]
+          },
+          {
+            "idx": 128,
+            "events": [
+              {
+                "pitch": 70,
+                "velocity": 108,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 61,
+                "velocity": 106,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 75,
+                "velocity": 115,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 136,
+            "events": [
+              {
+                "pitch": 72,
+                "velocity": 100,
+                "lengthSteps": 4,
+                "microshiftMs": 5
+              },
+              {
+                "pitch": 64,
+                "velocity": 100,
+                "lengthSteps": 4,
+                "microshiftMs": 6
+              }
+            ]
+          },
+          {
+            "idx": 160,
+            "events": [
+              {
+                "pitch": 67,
+                "velocity": 105,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 68,
+                "velocity": 112,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 172,
+            "events": [
+              {
+                "pitch": 73,
+                "velocity": 106,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 192,
+            "events": [
+              {
+                "pitch": 63,
+                "velocity": 102,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 71,
+                "velocity": 108,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 204,
+            "events": [
+              {
+                "pitch": 68,
+                "velocity": 102,
+                "lengthSteps": 3,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 224,
+            "events": [
+              {
+                "pitch": 60,
+                "velocity": 100,
+                "lengthSteps": 4,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 64,
+                "velocity": 110,
+                "lengthSteps": 5,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 256,
+            "events": [
+              {
+                "pitch": 71,
+                "velocity": 112,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 62,
+                "velocity": 110,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 75,
+                "velocity": 118,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 264,
+            "events": [
+              {
+                "pitch": 73,
+                "velocity": 104,
+                "lengthSteps": 4,
+                "microshiftMs": 5
+              },
+              {
+                "pitch": 65,
+                "velocity": 104,
+                "lengthSteps": 4,
+                "microshiftMs": 6
+              }
+            ]
+          },
+          {
+            "idx": 288,
+            "events": [
+              {
+                "pitch": 68,
+                "velocity": 109,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 69,
+                "velocity": 116,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 300,
+            "events": [
+              {
+                "pitch": 74,
+                "velocity": 108,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 320,
+            "events": [
+              {
+                "pitch": 64,
+                "velocity": 106,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 72,
+                "velocity": 112,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 332,
+            "events": [
+              {
+                "pitch": 69,
+                "velocity": 106,
+                "lengthSteps": 3,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 352,
+            "events": [
+              {
+                "pitch": 61,
+                "velocity": 104,
+                "lengthSteps": 4,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 65,
+                "velocity": 114,
+                "lengthSteps": 5,
+                "microshiftMs": 1
+              }
+            ]
+          },
+          {
+            "idx": 384,
+            "events": [
+              {
+                "pitch": 72,
+                "velocity": 116,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 63,
+                "velocity": 114,
+                "lengthSteps": 4,
+                "microshiftMs": 0
+              },
+              {
+                "pitch": 75,
+                "velocity": 121,
+                "lengthSteps": 2,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 392,
+            "events": [
+              {
+                "pitch": 74,
+                "velocity": 108,
+                "lengthSteps": 4,
+                "microshiftMs": 5
+              },
+              {
+                "pitch": 66,
+                "velocity": 108,
+                "lengthSteps": 4,
+                "microshiftMs": 6
+              }
+            ]
+          },
+          {
+            "idx": 416,
+            "events": [
+              {
+                "pitch": 69,
+                "velocity": 113,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              },
+              {
+                "pitch": 70,
+                "velocity": 120,
+                "lengthSteps": 6,
+                "microshiftMs": -4
+              }
+            ]
+          },
+          {
+            "idx": 428,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 110,
+                "lengthSteps": 3,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 448,
+            "events": [
+              {
+                "pitch": 65,
+                "velocity": 110,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              },
+              {
+                "pitch": 73,
+                "velocity": 116,
+                "lengthSteps": 4,
+                "microshiftMs": 2
+              }
+            ]
+          },
+          {
+            "idx": 460,
+            "events": [
+              {
+                "pitch": 70,
+                "velocity": 110,
+                "lengthSteps": 3,
+                "microshiftMs": -3
+              }
+            ]
+          },
+          {
+            "idx": 480,
+            "events": [
+              {
+                "pitch": 62,
+                "velocity": 108,
+                "lengthSteps": 4,
+                "microshiftMs": -2
+              },
+              {
+                "pitch": 66,
+                "velocity": 118,
+                "lengthSteps": 5,
+                "microshiftMs": 1
+              }
+            ]
+          }
+        ]
+      },
+      "ccLanes": [
+        {
+          "id": "lead_cutoff",
+          "dest": "name:cutoff",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 54
+            },
+            {
+              "t": {
+                "bar": 8,
+                "step": 0
+              },
+              "v": 76
+            },
+            {
+              "t": {
+                "bar": 24,
+                "step": 0
+              },
+              "v": 60
+            },
+            {
+              "t": {
+                "bar": 40,
+                "step": 0
+              },
+              "v": 88
+            }
+          ]
+        },
+        {
+          "id": "lead_fx1",
+          "dest": "name:send_fx1",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 48
+            },
+            {
+              "t": {
+                "bar": 12,
+                "step": 0
+              },
+              "v": 70
+            },
+            {
+              "t": {
+                "bar": 28,
+                "step": 0
+              },
+              "v": 58
+            },
+            {
+              "t": {
+                "bar": 44,
+                "step": 0
+              },
+              "v": 82
+            }
+          ]
+        },
+        {
+          "id": "lead_fx2",
+          "dest": "name:send_fx2",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 56
+            },
+            {
+              "t": {
+                "bar": 16,
+                "step": 0
+              },
+              "v": 84
+            },
+            {
+              "t": {
+                "bar": 32,
+                "step": 0
+              },
+              "v": 68
+            },
+            {
+              "t": {
+                "bar": 48,
+                "step": 0
+              },
+              "v": 94
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "t5-fx",
+      "name": "Risers & FX",
+      "type": "sampler",
+      "midiChannel": 4,
+      "role": "fx",
+      "pattern": {
+        "lengthBars": 32,
+        "steps": [
+          {
+            "idx": 0,
+            "events": [
+              {
+                "pitch": 73,
+                "velocity": 88,
+                "lengthSteps": 12,
+                "microshiftMs": -8
+              }
+            ]
+          },
+          {
+            "idx": 62,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 96,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 126,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 99,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 128,
+            "events": [
+              {
+                "pitch": 73,
+                "velocity": 92,
+                "lengthSteps": 12,
+                "microshiftMs": -8
+              }
+            ]
+          },
+          {
+            "idx": 190,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 102,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 254,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 105,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 256,
+            "events": [
+              {
+                "pitch": 73,
+                "velocity": 96,
+                "lengthSteps": 12,
+                "microshiftMs": -8
+              }
+            ]
+          },
+          {
+            "idx": 318,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 96,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 382,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 99,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 384,
+            "events": [
+              {
+                "pitch": 73,
+                "velocity": 100,
+                "lengthSteps": 12,
+                "microshiftMs": -8
+              }
+            ]
+          },
+          {
+            "idx": 446,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 102,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          },
+          {
+            "idx": 510,
+            "events": [
+              {
+                "pitch": 75,
+                "velocity": 105,
+                "lengthSteps": 8,
+                "microshiftMs": -6
+              },
+              {
+                "pitch": 66,
+                "velocity": 82,
+                "lengthSteps": 4,
+                "microshiftMs": 4
+              }
+            ]
+          }
+        ]
+      },
+      "ccLanes": [
+        {
+          "id": "fx_cutoff",
+          "dest": "name:cutoff",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 68
+            },
+            {
+              "t": {
+                "bar": 6,
+                "step": 0
+              },
+              "v": 92
+            },
+            {
+              "t": {
+                "bar": 18,
+                "step": 0
+              },
+              "v": 64
+            },
+            {
+              "t": {
+                "bar": 30,
+                "step": 0
+              },
+              "v": 96
+            },
+            {
+              "t": {
+                "bar": 44,
+                "step": 0
+              },
+              "v": 70
+            }
+          ]
+        },
+        {
+          "id": "fx_fx1",
+          "dest": "name:send_fx1",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 60
+            },
+            {
+              "t": {
+                "bar": 9,
+                "step": 0
+              },
+              "v": 82
+            },
+            {
+              "t": {
+                "bar": 21,
+                "step": 0
+              },
+              "v": 66
+            },
+            {
+              "t": {
+                "bar": 33,
+                "step": 0
+              },
+              "v": 90
+            }
+          ]
+        },
+        {
+          "id": "fx_fx2",
+          "dest": "name:send_fx2",
+          "mode": "ramp",
+          "points": [
+            {
+              "t": {
+                "bar": 0,
+                "step": 0
+              },
+              "v": 76
+            },
+            {
+              "t": {
+                "bar": 12,
+                "step": 0
+              },
+              "v": 96
+            },
+            {
+              "t": {
+                "bar": 27,
+                "step": 0
+              },
+              "v": 80
+            },
+            {
+              "t": {
+                "bar": 41,
+                "step": 0
+              },
+              "v": 104
+            }
+          ]
+        }
       ]
     }
   ],
-  "docVersion": 0
+  "docVersion": 1
 }
-


### PR DESCRIPTION
## Summary
- craft a 32-bar, 140 BPM trap loop in C minor with dedicated tracks for drums, hats, 808 bass, brass lead, and FX accents
- program halftime drum hits, rolling hi-hats with ratchets/triplets, sliding 808 phrases, and sparse cinematic lead/FX layers
- add long-form CC automation on filter cutoff and FX sends to keep the loop evolving beyond the 32-bar phrase

## Testing
- make validate FILE=loop.json

------
https://chatgpt.com/codex/tasks/task_e_68cac77630008330b2b5f7e90b83fd40